### PR TITLE
fix: add CJK font fallback for terminal

### DIFF
--- a/src/utils/terminalCache.ts
+++ b/src/utils/terminalCache.ts
@@ -40,7 +40,7 @@ export function getOrCreateTerminal(ptyId: number): CachedTerminal {
 
   const term = new Terminal({
     fontSize: useAppStore.getState().config.terminalFontSize ?? 14,
-    fontFamily: "'JetBrains Mono', 'Cascadia Code', Consolas, monospace",
+    fontFamily: "'JetBrains Mono', 'Cascadia Code', Consolas, 'Sarasa Term SC', monospace",
     fontWeight: '400',
     fontWeightBold: '600',
     cursorBlink: true,
@@ -79,7 +79,7 @@ export function getOrCreateTerminal(ptyId: number): CachedTerminal {
   term.loadAddon(fitAddon);
   term.open(wrapper);
 
-  // WebGL 渲染，降级时回退到 Canvas
+  // WebGL 渲染，降级时回退到 DOM
   try {
     const webgl = new WebglAddon();
     webgl.onContextLoss(() => {
@@ -88,7 +88,7 @@ export function getOrCreateTerminal(ptyId: number): CachedTerminal {
     });
     term.loadAddon(webgl);
   } catch {
-    // WebGL 不支持
+    // WebGL 不支持，回退到 DOM
   }
 
   // 剪贴板快捷键


### PR DESCRIPTION
## Summary
- Add `Sarasa Term SC` (更纱黑体) to the `fontFamily` fallback chain in xterm.js terminal config
- Without a monospace CJK font, Chinese characters render as garbled glyphs in the WebGL renderer
- Sarasa Term SC is designed for terminals — CJK chars are exactly 2x ASCII width, aligning with the WebGL cell grid

## Test plan
- [ ] Install `Sarasa Term SC` font (e.g. `brew install --cask font-sarasa-gothic`)
- [ ] Open Mini-Term terminal and verify Chinese characters render correctly
- [ ] Verify English/ASCII characters are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)