### PR TITLE
fix: 会话正文读取入口统一 session id 白名单 —— 前端参数不入路径拼接

### DIFF
--- a/src-tauri/src/ai_sessions.rs
+++ b/src-tauri/src/ai_sessions.rs
@@ -73,14 +73,17 @@ fn extract_session_cwd(jsonl: &str) -> Option<String> {
 /// 原目录才能恢复;桶目录名是有损编码(所有非字母数字都变 `-`),不做反解码,
 /// 直接按 `<id>.jsonl` 文件名精确命中后读记录内的真实 cwd。
 /// 供续接链路对无 cwd 的存量 pane 记录做兜底反查,查到由前端写回持久化。
+/// session id 白名单:字母数字与 `-` `_`(Claude UUID / Codex rollout id /
+/// Grok UUIDv7 均落在其中)。id 来自前端 invoke 参数或持久化数据,不可信,
+/// 拼进文件路径前必须过这道,挡 `../` 一类穿越。
+pub(crate) fn session_id_path_safe(id: &str) -> bool {
+    !id.is_empty() && id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
 #[tauri::command]
 pub fn lookup_ai_session_cwd(session_id: String) -> Option<String> {
     // 与前端 resume 命令的校验同口径,顺带防路径拼接注入
-    if session_id.is_empty()
-        || !session_id
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-    {
+    if !session_id_path_safe(&session_id) {
         return None;
     }
     let projects = home_dir()?.join(".claude").join("projects");
@@ -968,6 +971,10 @@ pub fn get_ai_session_content(
     project_path: String,
     wsl_distro: Option<String>,
 ) -> Result<Vec<AiSessionMessage>, String> {
+    // id 会拼进各家会话文件路径(本机/WSL 的 `<id>.jsonl`),统一在分发口挡穿越
+    if !session_id_path_safe(&session_id) {
+        return Err("非法会话 id".to_string());
+    }
     if let Some(distro) = wsl_distro.filter(|d| !d.is_empty()) {
         // WSL 根项目的 distro 以路径解析为准(与 get_wsl_ai_sessions 口径一致)
         let (distro, unix_cwd) = derive_wsl_target(&project_path, Some(distro))
@@ -1409,6 +1416,30 @@ fn read_grok_session_content(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- session id 白名单 ----
+
+    #[test]
+    fn session_id_path_safe_rejects_traversal_and_metachars() {
+        assert!(session_id_path_safe("0198c2f4-7e4a-7b3c-9d2e-1f0a2b3c4d5e"));
+        assert!(session_id_path_safe("abc_123"));
+        assert!(!session_id_path_safe(""));
+        assert!(!session_id_path_safe("../../etc/passwd"));
+        assert!(!session_id_path_safe("a/b"));
+        assert!(!session_id_path_safe("a b"));
+    }
+
+    #[test]
+    fn get_ai_session_content_rejects_bad_id_before_fs() {
+        // 分发口即拒绝,不落到任何文件系统访问
+        let r = get_ai_session_content(
+            "claude".into(),
+            "../../etc/passwd".into(),
+            "/tmp".into(),
+            None,
+        );
+        assert!(r.is_err());
+    }
 
     // ---- Grok Build ----
 

--- a/src-tauri/src/remote_ssh.rs
+++ b/src-tauri/src/remote_ssh.rs
@@ -31,8 +31,8 @@ use tauri::AppHandle;
 use crate::ai_sessions::{
     claude_message_from_line, claude_session_info_from_lines, codex_message_from_line,
     codex_meta_from_line, codex_user_title_from_line, encode_project_path, is_encoded_variant,
-    normalize_unix_path, session_cache, AiSession, AiSessionMessage, CachedSessions,
-    MAX_SESSIONS_PER_SOURCE, MAX_TOTAL_SESSIONS,
+    normalize_unix_path, session_cache, session_id_path_safe, AiSession, AiSessionMessage,
+    CachedSessions, MAX_SESSIONS_PER_SOURCE, MAX_TOTAL_SESSIONS,
 };
 use crate::fs::{natural_cmp, FileEntry, ALWAYS_IGNORE};
 
@@ -969,6 +969,10 @@ pub async fn ssh_remote_ai_session_content(
     project_path: String,
     offset: Option<u64>,
 ) -> Result<RemoteSessionContent, String> {
+    // id 会拼进远程路径(`<id>.jsonl`)与缓存键,统一在 command 口挡穿越
+    if !session_id_path_safe(&session_id) {
+        return Err("非法会话 id".to_string());
+    }
     let conn = find_connection(&app, &connection_id)?;
     let sftp = open_sftp(&state, &conn).await?;
     let result = async {


### PR DESCRIPTION
## 背景

#47 review 点出 `find_claude_session_file` 的 sessionId 白名单缺口（已在该 PR 内修复）后，顺手排查了仓库其余的 `<session_id>.jsonl` 路径拼接点：

- `mobile_mirror.rs` —— 已有 `valid_session_id` 前置校验 ✓
- `lookup_ai_session_cwd` —— 已有内联白名单 ✓
- `read_claude_session_content` / `read_wsl_claude_session_content` / `locate_remote_session_file`（SSH 远程）—— **无校验**，session_id 从前端 invoke 参数直达路径拼接

本地信任模型下风险很低（与 #47 review 对该类问题的定性一致），但口径既已立起，一并收掉。

## 改动

- `ai_sessions.rs` 抽 `pub(crate) session_id_path_safe`（字母数字与 `-` `_`，Claude UUID / Codex rollout id / Grok UUIDv7 均落在其中）
- `get_ai_session_content`（本机/WSL 共同分发口）与 `ssh_remote_ai_session_content`（SSH 远程）在 command 入口统一过检，上述三处拼接全部被覆盖；codex/grok 分支顺带受益（grok 的会话定位是目录名比较、本无拼接，过检无碍）
- `lookup_ai_session_cwd` 的同款内联校验收敛到同一函数，行为零变化
- `mobile_mirror::valid_session_id` 保持独立 —— 它的允许集刻意更窄（无下划线），语境是 hook 上报口

## 验证

- `cargo test`：424 过 0 挂（新增 `session_id_path_safe` 正负例、`get_ai_session_content` 拒穿越 2 条）
- 与 #47 相互独立：基于 main（120e1f3）分支，两边可按任意顺序合并