### PR TITLE
fix: 优化 Activity Bar 悬浮提示交互

### DIFF
--- a/crates/mt-app/src/activity_bar.rs
+++ b/crates/mt-app/src/activity_bar.rs
@@ -20,13 +20,15 @@
 //! 「跳到已完成」。(Git 那颗由 V 批补上,与右抽屉的 sessions⇄git 段控件同一个开关;
 //! 移动端那颗由 U 批补上,位置照原版排在「设置」之前。)
 
+use std::time::Duration;
+
 use gpui::{
-    AnimationExt as _, AnyElement, Animation, Div, ElementId, Hsla, InteractiveElement, IntoElement,
-    ParentElement, SharedString, Stateful, StatefulInteractiveElement, Styled, div,
-    prelude::FluentBuilder as _, px,
+    Animation, AnimationExt as _, AnyElement, App, Div, ElementId, Hsla, InteractiveElement,
+    IntoElement, ParentElement, RenderOnce, SharedString, Stateful, StatefulInteractiveElement,
+    Styled, Window, div, prelude::FluentBuilder as _, px, rems,
 };
-use mt_ui::tooltip::Tooltip;
-use mt_ui::icons::{Geom, Ink, Shape, VectorIcon};
+use gpui_component::ActiveTheme as _;
+use mt_ui::icons::{Geom, Ink, Shape, StatusDot, StatusKind, VectorIcon};
 
 use crate::tree::PaneStatus;
 use crate::ui;
@@ -37,6 +39,143 @@ pub const WIDTH: f32 = 44.0;
 const BUTTON: f32 = 32.0;
 /// 图标尺寸。原版每个 svg 都是 `width="18" height="18"`。
 const ICON: f32 = 18.0;
+/// 一次新的边条悬停会话里,第一条文字提示要停多久才出现。
+///
+/// 这是**完整延迟**,不再叠加全局 [`mt_ui::tooltip::Tooltip`] 的额外 700ms。
+pub const HOVER_SHOW_DELAY: Duration = Duration::from_millis(500);
+/// 按钮在 44px 边条里左右各留 6px;提示从按钮右缘再跨过这 6px,
+/// 正好从边条右缘开始画。
+const LABEL_GAP: f32 = (WIDTH - BUTTON) / 2.0;
+/// 与全局 tooltip 同一档字号(0.75rem),只把定位与计时收归 Activity Bar。
+const LABEL_FONT_SIZE: f32 = 0.75;
+
+/// 进入一颗 Activity Bar 按钮之后,宿主该做什么。
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HoverEnter {
+    /// 重复收到同一颗按钮的 enter,状态没有变化。
+    Unchanged,
+    /// 新会话的第一条提示要起表;值是本次计时的代号。
+    Delay(u64),
+    /// 本次会话已经热身,提示已在状态机里切到新按钮,直接重画即可。
+    ShowNow,
+}
+
+/// Activity Bar 整组按钮共用的悬停会话。
+///
+/// 这台状态机不碰时钟:宿主按 [`HoverEnter::Delay`] 起计时,到点后带
+/// `generation` 回来对账。Task drop 是第一道取消,代号是竞态下的第二道闸。
+#[derive(Debug, Default)]
+pub struct HoverSession {
+    hovered: Option<&'static str>,
+    visible: Option<&'static str>,
+    warmed: bool,
+    generation: u64,
+}
+
+impl HoverSession {
+    /// 进入一颗按钮。热身前返回计时代号,热身后当场切换可见标签。
+    pub fn enter(&mut self, key: &'static str) -> HoverEnter {
+        if self.hovered == Some(key) {
+            return HoverEnter::Unchanged;
+        }
+
+        self.generation = self.generation.wrapping_add(1);
+        self.hovered = Some(key);
+        if self.warmed {
+            self.visible = Some(key);
+            HoverEnter::ShowNow
+        } else {
+            self.visible = None;
+            HoverEnter::Delay(self.generation)
+        }
+    }
+
+    /// 离开一颗按钮。只有离开的仍是当前目标才清理 —— 相邻按钮的 enter/leave
+    /// 到达顺序不保证,旧按钮的迟到 leave 不能抹掉新按钮。
+    pub fn leave(&mut self, key: &'static str) -> bool {
+        if self.hovered != Some(key) {
+            return false;
+        }
+        self.generation = self.generation.wrapping_add(1);
+        self.hovered = None;
+        self.visible = None;
+        true
+    }
+
+    /// 第一段停留到点。仍悬着同一颗且代号没过期才真正显示并热身。
+    pub fn on_delay_elapsed(&mut self, generation: u64, key: &'static str) -> bool {
+        if self.warmed || self.generation != generation || self.hovered != Some(key) {
+            return false;
+        }
+        self.warmed = true;
+        self.visible = Some(key);
+        true
+    }
+
+    /// 离开整条边条:隐藏、降温并让所有在飞的旧计时失效。
+    pub fn reset(&mut self) -> bool {
+        let changed = self.hovered.is_some() || self.visible.is_some() || self.warmed;
+        self.generation = self.generation.wrapping_add(1);
+        self.hovered = None;
+        self.visible = None;
+        self.warmed = false;
+        changed
+    }
+
+    /// 当前是否该在这颗按钮右侧画文字。
+    pub fn is_visible(&self, key: &'static str) -> bool {
+        self.visible == Some(key)
+    }
+}
+
+/// Activity Bar 专用的文字表面。定位壳高 32px 并 `items_center`,所以文字高度
+/// 无论随主题字号怎么变,都始终相对按钮垂直居中。
+#[derive(IntoElement)]
+struct HoverLabel {
+    text: SharedString,
+}
+
+impl RenderOnce for HoverLabel {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        div()
+            .absolute()
+            .left(px(BUTTON + LABEL_GAP))
+            .top_0()
+            .h(px(BUTTON))
+            .flex()
+            .items_center()
+            .child(
+                div()
+                    .font_family(cx.theme().font_family.clone())
+                    .whitespace_nowrap()
+                    .bg(cx.theme().popover)
+                    .text_color(cx.theme().popover_foreground)
+                    .border_1()
+                    .border_color(cx.theme().border)
+                    .shadow_md()
+                    .rounded(px(6.0))
+                    .py(px(2.0))
+                    .px(px(8.0))
+                    .text_size(rems(LABEL_FONT_SIZE))
+                    .child(self.text),
+            )
+    }
+}
+
+/// 三种按钮共用的 hover 接线与标签表面,避免 update / unread 走出另一套手感。
+fn with_hover_label<F>(
+    button: Stateful<Div>,
+    tip: SharedString,
+    label_visible: bool,
+    on_hover: F,
+) -> Stateful<Div>
+where
+    F: Fn(&bool, &mut Window, &mut App) + 'static,
+{
+    button
+        .on_hover(on_hover)
+        .when(label_visible, move |el| el.child(HoverLabel { text: tip }))
+}
 
 /// 单位方框换算:原版 viewBox 是 `0 0 16 16`,除以 16 即可。
 const fn u(v: f32) -> f32 {
@@ -346,9 +485,17 @@ pub const UPDATE: &[Shape] = &[
 /// [`corner_dot`]。⚠️ 闪烁过 [`mt_ui::motion`] 的闸:`.animate-blink` **不在**
 /// 原版 reduce 段的豁免名单里,系统开着「减少动画」时装机版本来就不闪 ——
 /// 这里同样静止,见 [`update_dot_blinks`]。
-pub fn update_button(id: impl Into<ElementId>, tip: SharedString) -> Stateful<Div> {
-    div()
-        .id(id)
+pub fn update_button<F>(
+    key: &'static str,
+    tip: impl Into<SharedString>,
+    label_visible: bool,
+    on_hover: F,
+) -> Stateful<Div>
+where
+    F: Fn(&bool, &mut Window, &mut App) + 'static,
+{
+    let button = div()
+        .id(key)
         .relative()
         .flex()
         .items_center()
@@ -363,8 +510,9 @@ pub fn update_button(id: impl Into<ElementId>, tip: SharedString) -> Stateful<Di
         .child(VectorIcon::new(UPDATE, px(ICON)).ink(ui::accent()))
         // `absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-accent
         //  border border-[var(--bg-surface)] animate-blink`
-        .child(corner_dot("update-dot", ui::accent(), update_dot_blinks()))
-        .tooltip(move |window, cx| Tooltip::new(tip.clone()).build(window, cx))
+        .child(corner_dot("update-dot", ui::accent(), update_dot_blinks()));
+
+    with_hover_label(button, tip.into(), label_visible, on_hover)
 }
 
 /// 一个边条按钮的外壳(不含 `on_click`,由调用方挂)。
@@ -373,19 +521,24 @@ pub fn update_button(id: impl Into<ElementId>, tip: SharedString) -> Stateful<Di
 /// 未激活 = 淡字、hover 转主文本色;激活时左侧还有一根 accent 竖条
 /// (原版 `ACCENT_BAR`,**始终占位**靠透明度切换的写法在 gpui 里没必要,
 /// 这里直接按需追加子元素)。
-pub fn strip_button(
-    id: impl Into<ElementId>,
+pub fn strip_button<F>(
+    key: &'static str,
     shapes: &'static [Shape],
-    tip: &'static str,
+    tip: impl Into<SharedString>,
     active: bool,
-) -> Stateful<Div> {
+    label_visible: bool,
+    on_hover: F,
+) -> Stateful<Div>
+where
+    F: Fn(&bool, &mut Window, &mut App) + 'static,
+{
     let color = if active {
         ui::text_primary()
     } else {
         ui::text_muted()
     };
-    div()
-        .id(id)
+    let button = div()
+        .id(key)
         .relative()
         .flex()
         .items_center()
@@ -409,8 +562,42 @@ pub fn strip_button(
                     .rounded(px(1.0))
                     .bg(ui::accent()),
             )
-        })
-        .tooltip(move |window, cx| Tooltip::new(tip).build(window, cx))
+        });
+
+    with_hover_label(button, tip.into(), label_visible, on_hover)
+}
+
+/// 未读完成入口。图形与行为仍是原来的成功状态点,只把 Activity Bar 三类按钮的
+/// 尺寸、hover 接线和右侧标签统一到同一个构造路径。
+pub fn done_button<F>(
+    key: &'static str,
+    tip: impl Into<SharedString>,
+    label_visible: bool,
+    on_hover: F,
+) -> Stateful<Div>
+where
+    F: Fn(&bool, &mut Window, &mut App) + 'static,
+{
+    let button = div()
+        .id(key)
+        .relative()
+        .flex()
+        .items_center()
+        .justify_center()
+        .w(px(BUTTON))
+        .h(px(BUTTON))
+        .flex_none()
+        .rounded(px(4.0))
+        .cursor_pointer()
+        .hover(|el| el.bg(ui::border_subtle()))
+        .child(
+            StatusDot::new("strip-unread-done", StatusKind::AiIdle)
+                .size(px(14.0))
+                .color(ui::color_success())
+                .contrast(ui::bg_surface()),
+        );
+
+    with_hover_label(button, tip.into(), label_visible, on_hover)
 }
 
 /// 全局 AI 状态徽标(挂在「折叠中间栏」那颗按钮的右上角)。
@@ -510,6 +697,76 @@ pub fn divider() -> Div {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn 首条提示延迟显示并把会话热身() {
+        let mut session = HoverSession::default();
+        let HoverEnter::Delay(generation) = session.enter("one") else {
+            panic!("新会话第一颗按钮必须起表");
+        };
+        assert!(!session.is_visible("one"), "停够 500ms 前不能先画出来");
+        assert!(session.on_delay_elapsed(generation, "one"));
+        assert!(session.is_visible("one"));
+        assert!(session.warmed);
+    }
+
+    #[test]
+    fn 热身后跨空隙切按钮立即显示() {
+        let mut session = HoverSession::default();
+        let HoverEnter::Delay(generation) = session.enter("one") else {
+            panic!("第一颗应起表");
+        };
+        assert!(session.on_delay_elapsed(generation, "one"));
+
+        assert!(session.leave("one"), "进空隙时隐藏当前标签");
+        assert!(!session.is_visible("one"));
+        assert!(session.warmed, "空隙不等于离开整条边条");
+
+        assert_eq!(session.enter("two"), HoverEnter::ShowNow);
+        assert!(session.is_visible("two"));
+    }
+
+    #[test]
+    fn 离开整条边条后下次重新等待() {
+        let mut session = HoverSession::default();
+        let HoverEnter::Delay(generation) = session.enter("one") else {
+            panic!("第一颗应起表");
+        };
+        assert!(session.on_delay_elapsed(generation, "one"));
+        assert!(session.reset());
+        assert!(!session.warmed);
+        assert!(!session.is_visible("one"));
+        assert!(matches!(session.enter("two"), HoverEnter::Delay(_)));
+    }
+
+    #[test]
+    fn 旧计时与旧按钮的迟到离开都不能覆盖新目标() {
+        let mut session = HoverSession::default();
+        let HoverEnter::Delay(old_generation) = session.enter("one") else {
+            panic!("第一颗应起表");
+        };
+        let HoverEnter::Delay(new_generation) = session.enter("two") else {
+            panic!("热身前切换目标应为新目标重新起表");
+        };
+
+        assert!(!session.leave("one"), "旧按钮的 leave 不能清掉新按钮");
+        assert!(!session.on_delay_elapsed(old_generation, "one"));
+        assert!(!session.is_visible("one"));
+        assert!(session.on_delay_elapsed(new_generation, "two"));
+        assert!(session.is_visible("two"));
+
+        assert_eq!(session.enter("three"), HoverEnter::ShowNow);
+        assert!(!session.leave("two"), "热身后的旧 leave 同样不能清新标签");
+        assert!(session.is_visible("three"));
+    }
+
+    #[test]
+    fn 延迟与标签起点钉在边条几何上() {
+        assert_eq!(HOVER_SHOW_DELAY, Duration::from_millis(500));
+        // 按钮左侧留白 + 标签相对按钮的 left = 44px 边条右缘。
+        assert_eq!(LABEL_GAP + BUTTON + LABEL_GAP, WIDTH);
+        assert_eq!(BUTTON, 32.0, "定位壳高度跟按钮高度同源");
+    }
 
     /// 形状表的点必须全落在单位方框内 —— 越界会画到相邻按钮上。
     /// (mt-ui 对自己那批图标有同名约束,这里是本 crate 这四张表的同款体检。)

--- a/crates/mt-app/src/main.rs
+++ b/crates/mt-app/src/main.rs
@@ -125,7 +125,6 @@ use gpui::{
 use gpui::StyledImage as _;
 use gpui_component::resizable::{ResizableState, h_resizable, resizable_panel, v_resizable};
 use gpui_component::{Root, WindowExt as _};
-use mt_ui::icons::{StatusDot, StatusKind};
 use mt_ui::tooltip::Tooltip;
 
 use crate::ai::AiBridge;
@@ -368,6 +367,11 @@ struct Workspace {
     /// 抽屉左缘正在被拖。`Some` 期间宽度由本结构自持,松手才落盘。
     drawer_drag: Option<DrawerDrag>,
     usage_open: bool,
+    /// 左侧 Activity Bar 整组按钮共用的 VS Code 式悬停会话。
+    activity_bar_hover: activity_bar::HoverSession,
+    /// 新会话第一条标签的 500ms 计时。drop 句柄立即取消;状态机的 generation
+    /// 再挡住已经进入回调队列的旧任务。
+    activity_bar_hover_task: Option<Task<()>>,
     /// 弹窗毛玻璃背板的快照(见 [`frost`] 模块注释)。弹窗/用量面板从无到有的
     /// 第一帧抓一次,期间沿用,全关即弃 —— 开着时再抓会把弹窗自己抓进去。
     frost: Option<std::sync::Arc<gpui::RenderImage>>,
@@ -539,6 +543,8 @@ impl Workspace {
             drawer_exit: None,
             drawer_drag: None,
             usage_open: false,
+            activity_bar_hover: activity_bar::HoverSession::default(),
+            activity_bar_hover_task: None,
             frost: None,
             frost_task: None,
             update_release: None,
@@ -554,6 +560,76 @@ impl Workspace {
         // 布局里本来就可能有跑着的 AI 会话。
         workspace.sync_tray(cx);
         workspace
+    }
+
+    /// 一颗 Activity Bar 按钮的 enter / leave。热身前排一次 500ms 计时;
+    /// 热身后只改状态并立即重画。
+    fn on_activity_bar_item_hover(
+        &mut self,
+        key: &'static str,
+        hovered: bool,
+        cx: &mut Context<Self>,
+    ) {
+        if hovered {
+            match self.activity_bar_hover.enter(key) {
+                activity_bar::HoverEnter::Unchanged => {}
+                activity_bar::HoverEnter::ShowNow => {
+                    self.activity_bar_hover_task = None;
+                    cx.notify();
+                }
+                activity_bar::HoverEnter::Delay(generation) => {
+                    // 覆盖句柄 = clearTimeout。generation 是旧回调已经排进队列时的
+                    // 第二道闸,两条都保留才不会补弹过期标签。
+                    self.activity_bar_hover_task = None;
+                    self.activity_bar_hover_task = Some(cx.spawn(async move |this, cx| {
+                        cx.background_executor()
+                            .timer(activity_bar::HOVER_SHOW_DELAY)
+                            .await;
+                        let _ = this.update(cx, |workspace: &mut Self, cx| {
+                            if workspace
+                                .activity_bar_hover
+                                .on_delay_elapsed(generation, key)
+                            {
+                                workspace.activity_bar_hover_task = None;
+                                cx.notify();
+                            }
+                        });
+                    }));
+                    cx.notify();
+                }
+            }
+        } else if self.activity_bar_hover.leave(key) {
+            self.activity_bar_hover_task = None;
+            cx.notify();
+        }
+    }
+
+    /// 给每颗 Activity Bar 按钮生成同款 hover 监听器。key 同时是按钮 id 与
+    /// [`activity_bar::HoverSession`] 的稳定身份,集中在这里避免十处闭包漂移。
+    fn activity_bar_item_hover_listener(
+        key: &'static str,
+        cx: &Context<Self>,
+    ) -> impl Fn(&bool, &mut Window, &mut App) + 'static {
+        cx.listener(move |this, hovered: &bool, _window, cx| {
+            this.on_activity_bar_item_hover(key, *hovered, cx);
+        })
+    }
+
+    /// 只有离开**整条** Activity Bar 才降温;经过按钮间空隙只由按钮 leave
+    /// 隐藏标签,保留 warmed 状态。
+    fn on_activity_bar_hover(
+        &mut self,
+        hovered: &bool,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if *hovered {
+            return;
+        }
+        self.activity_bar_hover_task = None;
+        if self.activity_bar_hover.reset() {
+            cx.notify();
+        }
     }
 
     /// 把 store 的当前状态压成一份托盘快照推下去(`store.ts::syncTrayStatus`)。
@@ -1224,6 +1300,15 @@ impl Render for Workspace {
             )
         };
 
+        // 条件按钮可能在鼠标仍停在原坐标时从元素树消失,这时 GPUI 不保证再补一发
+        // on_hover(false)。主动按当前可见性对账,避免它的旧计时把会话偷偷热身。
+        let conditional_hover_gone = (unread == 0
+            && self.activity_bar_hover.leave("jump-attention"))
+            || (self.update_release.is_none() && self.activity_bar_hover.leave("open-update"));
+        if conditional_hover_gone {
+            self.activity_bar_hover_task = None;
+        }
+
         // 弹窗毛玻璃背板:Dialog 族或用量面板**从无到有的第一帧**抓一次快照
         // (那一刻 DWM 的上一帧还没有弹窗),期间沿用,全关即弃 —— 开着时再抓
         // 会把弹窗自己抓进去。抓帧同步(PrintWindow 有窗口线程亲和性,也快),
@@ -1368,7 +1453,12 @@ impl Render for Workspace {
         // 原版 8 颗按钮至此全部就位(BB-b 补上最后一颗 SSH);末尾那颗
         // 「跳到已完成」是 GPUI 独有的。
         let toggle_strip = div()
-            .flex_none()
+            .id("activity-bar")
+            // 视觉层稍后排在 columns 之后画;body 里另留一块 44px 占位。
+            // 这样按钮右侧标签能盖住相邻内容,又仍低于后面的 drawer/toast/modal。
+            .absolute()
+            .left_0()
+            .top_0()
             .w(px(activity_bar::WIDTH))
             .h_full()
             .flex()
@@ -1379,6 +1469,7 @@ impl Render for Workspace {
             .bg(ui::bg_surface())
             .border_r_1()
             .border_color(ui::border_subtle())
+            .on_hover(cx.listener(Self::on_activity_bar_hover))
             .child(
                 activity_bar::strip_button(
                     "toggle-middle",
@@ -1389,6 +1480,8 @@ impl Render for Workspace {
                         t("app", "activityBar.expand")
                     },
                     middle_visible,
+                    self.activity_bar_hover.is_visible("toggle-middle"),
+                    Self::activity_bar_item_hover_listener("toggle-middle", cx),
                 )
                 // 全局 AI 状态徽标挂在这颗按钮上(中间栏承载项目列表)。
                 // 口径与原版一致:只反映 AI 状态,**error 不往上冒** ——
@@ -1410,6 +1503,8 @@ impl Render for Workspace {
                     activity_bar::SESSIONS,
                     t("app", "activityBar.sessions"),
                     self.right_drawer == Some(DrawerPanel::Sessions),
+                    self.activity_bar_hover.is_visible("toggle-sessions"),
+                    Self::activity_bar_item_hover_listener("toggle-sessions", cx),
                 )
                 .on_click(cx.listener(|this, _event, _window, cx| {
                     this.toggle_drawer(DrawerPanel::Sessions, cx)
@@ -1423,6 +1518,8 @@ impl Render for Workspace {
                     activity_bar::GIT,
                     t("app", "activityBar.git"),
                     self.right_drawer == Some(DrawerPanel::Git),
+                    self.activity_bar_hover.is_visible("toggle-git"),
+                    Self::activity_bar_item_hover_listener("toggle-git", cx),
                 )
                 .on_click(cx.listener(|this, _event, _window, cx| {
                     this.toggle_drawer(DrawerPanel::Git, cx)
@@ -1436,6 +1533,8 @@ impl Render for Workspace {
                     activity_bar::TERMINALS,
                     t("app", "activityBar.terminals"),
                     terminals_visible,
+                    self.activity_bar_hover.is_visible("toggle-terminals"),
+                    Self::activity_bar_item_hover_listener("toggle-terminals", cx),
                 )
                 .on_click(cx.listener(|this, _event, _window, cx| {
                     this.store
@@ -1449,6 +1548,8 @@ impl Render for Workspace {
                     activity_bar::STATS,
                     t("app", "activityBar.stats"),
                     self.usage_open,
+                    self.activity_bar_hover.is_visible("toggle-usage"),
+                    Self::activity_bar_item_hover_listener("toggle-usage", cx),
                 )
                 .on_click(cx.listener(|this, _event, window, cx| this.toggle_usage(window, cx))),
             )
@@ -1461,6 +1562,8 @@ impl Render for Workspace {
                     activity_bar::SETTINGS,
                     t("app", "activityBar.settings"),
                     false,
+                    self.activity_bar_hover.is_visible("open-settings"),
+                    Self::activity_bar_item_hover_listener("open-settings", cx),
                 )
                 .on_click(cx.listener(|this, _event, window, cx| {
                     settings::open_settings(this.store.clone(), None, window, cx);
@@ -1473,6 +1576,8 @@ impl Render for Workspace {
                     activity_bar::SSH,
                     t("app", "activityBar.ssh"),
                     false,
+                    self.activity_bar_hover.is_visible("open-ssh"),
+                    Self::activity_bar_item_hover_listener("open-ssh", cx),
                 )
                 .on_click(cx.listener(|_this, _event, window, cx| {
                     ssh_panel::open(window, cx);
@@ -1484,6 +1589,8 @@ impl Render for Workspace {
                     activity_bar::MOBILE,
                     t("app", "activityBar.mobile"),
                     false,
+                    self.activity_bar_hover.is_visible("open-mobile-relay"),
+                    Self::activity_bar_item_hover_listener("open-mobile-relay", cx),
                 )
                 .on_click(cx.listener(|_this, _event, window, cx| {
                     mobile_panel::open(window, cx);
@@ -1497,7 +1604,9 @@ impl Render for Workspace {
                 let url = release.url.clone();
                 activity_bar::update_button(
                     "open-update",
-                    tr!("app", "update.title", version = release.version.as_str()).into(),
+                    tr!("app", "update.title", version = release.version.as_str()),
+                    self.activity_bar_hover.is_visible("open-update"),
+                    Self::activity_bar_item_hover_listener("open-update", cx),
                 )
                 .on_click(move |_event, _window, cx: &mut gpui::App| {
                     cx.open_url(&url);
@@ -1507,29 +1616,15 @@ impl Render for Workspace {
             // 原版边栏没有这颗按钮,所以借状态灯的「实心圆 + 勾」当图形)
             .when(unread > 0, |el| {
                 el.child(
-                    div()
-                        .id("jump-attention")
-                        .flex()
-                        .items_center()
-                        .justify_center()
-                        .w(px(32.0))
-                        .h(px(32.0))
-                        .flex_none()
-                        .rounded(px(4.0))
-                        .cursor_pointer()
-                        .hover(|el| el.bg(ui::border_subtle()))
-                        .tooltip(move |window, cx| {
-                            Tooltip::new(t("app", "titleBar.status.done")).build(window, cx)
-                        })
-                        .child(
-                            StatusDot::new("strip-unread-done", StatusKind::AiIdle)
-                                .size(px(14.0))
-                                .color(ui::color_success())
-                                .contrast(ui::bg_surface()),
-                        )
-                        .on_click(cx.listener(|this, _event, window, cx| {
-                            this.on_jump_attention(&JumpAttention, window, cx);
-                        })),
+                    activity_bar::done_button(
+                        "jump-attention",
+                        t("app", "titleBar.status.done"),
+                        self.activity_bar_hover.is_visible("jump-attention"),
+                        Self::activity_bar_item_hover_listener("jump-attention", cx),
+                    )
+                    .on_click(cx.listener(|this, _event, window, cx| {
+                        this.on_jump_attention(&JumpAttention, window, cx);
+                    })),
                 )
             });
 
@@ -1739,8 +1834,11 @@ impl Render for Workspace {
             .overflow_hidden()
             .relative()
             .flex()
-            .child(toggle_strip)
+            // Activity Bar 的 flex 占位仍是 44px;视觉条本体在 columns 后面以
+            // absolute sibling 画,让右伸的标签不被 columns 覆盖。
+            .child(div().flex_none().w(px(activity_bar::WIDTH)).h_full())
             .child(div().flex_1().h_full().child(columns_group))
+            .child(toggle_strip)
             .children(drawer_layer)
             // 自建 toast 层。挂在 `body`(它是 `relative`)里而不是根上 ——
             // 原版 `.toast-stack` 贴的是视口右下角(`fixed right:16 bottom:16`),


### PR DESCRIPTION
## 变更

- Activity Bar 首次悬停约 500ms 后显示文字提示，移除原先约 1.2 秒的叠加延迟
- 首次提示显示后，在同一侧边栏图标间移动时立即切换提示
- 经过图标间空隙时隐藏提示但保留热状态；离开整个侧边栏后重置
- 使用任务取消与 generation 双重保护，避免过期计时器显示错误提示
- 提示固定显示在图标右侧并垂直居中，绘制层级低于抽屉、Toast 和弹窗
- 普通按钮、更新按钮和未读完成按钮统一使用同一套交互，不影响全局 Tooltip

## 验证

- 用户已使用 Windows 测试安装包完成实际交互验证
- GitHub Actions Build & Release 全部成功：Windows x64、macOS arm64、Linux x64
- Windows NSIS 安装包生成及 Release 上传成功
- Actions: https://github.com/vihor6/mini-term/actions/runs/32954300583
- Test release: https://github.com/vihor6/mini-term/releases/tag/v1.1.2-menu-tooltip-test.20260826.2