### PR TITLE
fix: 补齐五处 macOS 缺陷 —— 默认字族栈、粘贴键位、点击定位光标、关窗后 Dock 僵尸、统计浮层底色

### DIFF
--- a/crates/mt-app/src/main.rs
+++ b/crates/mt-app/src/main.rs
@@ -1821,6 +1821,20 @@ impl Render for Workspace {
                         .on_mouse_down(gpui::MouseButton::Left, |_event, _window, cx| {
                             cx.stop_propagation();
                         })
+                        // 面板体自己的底色。**别省这一行** —— 少了它面板就是全透明的,
+                        // 背后只剩那层 black/50,终端文字照样一个个看得清。
+                        //
+                        // Windows 上看不出来:根层那张毛玻璃快照垫在面板之下,透出来的是
+                        // 模糊+压暗的画面,勉强能读。但快照走 `PrintWindow` 是 Windows 专有
+                        // (见 `frost` 模块),**非 Windows 上 `frost` 恒为 `None`**,退化成
+                        // 纯 black/50 —— 隔着一层黑纱看锐利的终端正文,读不了。
+                        //
+                        // 用 `bg_overlay` 而不是 `bg_surface` / `bg_elevated`:后两者在外置
+                        // 主题包下会乘 `surface_opacity`(有背景图时要透出图),而浮层叠在任意
+                        // 内容之上,半透明是拿可读性换观感 —— 判据见 `ui::Palette::from_pack`
+                        // 里那一行注释。设置弹窗与 pane 预览 / 分支家族 / 日期选择器四处浮层
+                        // 用的都是它,这里是唯一漏掉的一个。
+                        .bg(ui::bg_overlay())
                         .rounded(px(6.0))
                         .border_1()
                         .border_color(ui::border_default())

--- a/crates/mt-app/src/main.rs
+++ b/crates/mt-app/src/main.rs
@@ -1787,94 +1787,98 @@ impl Render for Workspace {
         // 原版 `w-[80vw] max-h-[85vh]` + 外壳默认 `pt-[10vh]`(`Modal.tsx:162`):
         // 左右各留 10vw,顶 10vh、底 5vh(10vh + 85vh = 95vh)
         let usage_viewport = window.viewport_size();
-        let usage_layer = self.usage_panel.clone().filter(|_| self.usage_open).map(|panel| {
-            // 原版用量统计是 Modal(`UsageStatsModal.tsx:397`,fixed inset-0,
-            // **盖住标题栏**),遮罩统一 `bg-black/50 backdrop-blur-sm`
-            // (`Modal.tsx:171`)。毛玻璃由**根层那张共用快照**承担(与 Dialog
-            // 族同一层,见 render 尾部)—— 挂根层而不是 body:body 版本盖不到
-            // 标题栏、内嵌玻璃还会被拉伸错位,与设置弹窗观感不一致(用户实测)。
-            // 遮罩上**按下**即关(mousedown 语义 —— 面板里按下、拖出去松手
-            // 不误关);面板自己 stop_propagation 挡掉冒泡(`Modal.tsx:180` 同款)。
-            div()
-                .absolute()
-                .inset_0()
-                .occlude()
-                .bg(gpui::hsla(0.0, 0.0, 0.0, 0.5))
-                .on_mouse_down(
-                    gpui::MouseButton::Left,
-                    cx.listener(|this, _event, window, cx| {
-                        if this.usage_open {
-                            this.toggle_usage(window, cx);
-                        }
-                    }),
-                )
-                .child(
-                    div()
-                        .absolute()
-                        .top(usage_viewport.height * 0.10)
-                        .left(usage_viewport.width * 0.10)
-                        .right(usage_viewport.width * 0.10)
-                        .bottom(usage_viewport.height * 0.05)
-                        .occlude()
-                        // 面板内按下不冒泡到遮罩(原版 `Modal.tsx:180` 的
-                        // stopPropagation 同款),否则点面板空白处也会关窗
-                        .on_mouse_down(gpui::MouseButton::Left, |_event, _window, cx| {
-                            cx.stop_propagation();
-                        })
-                        // 面板体自己的底色。**别省这一行** —— 少了它面板就是全透明的,
-                        // 背后只剩那层 black/50,终端文字照样一个个看得清。
-                        //
-                        // Windows 上看不出来:根层那张毛玻璃快照垫在面板之下,透出来的是
-                        // 模糊+压暗的画面,勉强能读。但快照走 `PrintWindow` 是 Windows 专有
-                        // (见 `frost` 模块),**非 Windows 上 `frost` 恒为 `None`**,退化成
-                        // 纯 black/50 —— 隔着一层黑纱看锐利的终端正文,读不了。
-                        //
-                        // 用 `bg_overlay` 而不是 `bg_surface` / `bg_elevated`:后两者在外置
-                        // 主题包下会乘 `surface_opacity`(有背景图时要透出图),而浮层叠在任意
-                        // 内容之上,半透明是拿可读性换观感 —— 判据见 `ui::Palette::from_pack`
-                        // 里那一行注释。设置弹窗与 pane 预览 / 分支家族 / 日期选择器四处浮层
-                        // 用的都是它,这里是唯一漏掉的一个。
-                        .bg(ui::bg_overlay())
-                        .rounded(px(6.0))
-                        .border_1()
-                        .border_color(ui::border_default())
-                        .overflow_hidden()
-                        .flex()
-                        .flex_col()
-                        .child(
-                            div()
-                                .flex()
-                                .items_center()
-                                .justify_between()
-                                .px(px(12.0))
-                                .py(px(6.0))
-                                .bg(ui::bg_elevated())
-                                .child(
-                                    div()
-                                        .text_size(crate::ui::font_px(12.0))
-                                        .text_color(ui::text_primary())
-                                        .child(t("usageStats", "title")),
-                                )
-                                .child(
-                                    div()
-                                        .id("usage-close")
-                                        .px(px(6.0))
-                                        .text_color(ui::text_muted())
-                                        .cursor_pointer()
-                                        .hover(|el| el.text_color(ui::color_error()))
-                                        // 走 toggle 而不是直接改标志位 —— 可见性要透给
-                                        // 面板,否则关掉之后自动刷新定时器还在每 5s 跑
-                                        .on_click(cx.listener(|this, _event, window, cx| {
-                                            if this.usage_open {
-                                                this.toggle_usage(window, cx);
-                                            }
-                                        }))
-                                        .child("×"),
-                                ),
-                        )
-                        .child(div().flex_1().overflow_hidden().child(panel)),
-                )
-        });
+        let usage_layer = self
+            .usage_panel
+            .clone()
+            .filter(|_| self.usage_open)
+            .map(|panel| {
+                // 原版用量统计是 Modal(`UsageStatsModal.tsx:397`,fixed inset-0,
+                // **盖住标题栏**),遮罩统一 `bg-black/50 backdrop-blur-sm`
+                // (`Modal.tsx:171`)。毛玻璃由**根层那张共用快照**承担(与 Dialog
+                // 族同一层,见 render 尾部)—— 挂根层而不是 body:body 版本盖不到
+                // 标题栏、内嵌玻璃还会被拉伸错位,与设置弹窗观感不一致(用户实测)。
+                // 遮罩上**按下**即关(mousedown 语义 —— 面板里按下、拖出去松手
+                // 不误关);面板自己 stop_propagation 挡掉冒泡(`Modal.tsx:180` 同款)。
+                div()
+                    .absolute()
+                    .inset_0()
+                    .occlude()
+                    .bg(gpui::hsla(0.0, 0.0, 0.0, 0.5))
+                    .on_mouse_down(
+                        gpui::MouseButton::Left,
+                        cx.listener(|this, _event, window, cx| {
+                            if this.usage_open {
+                                this.toggle_usage(window, cx);
+                            }
+                        }),
+                    )
+                    .child(
+                        div()
+                            .absolute()
+                            .top(usage_viewport.height * 0.10)
+                            .left(usage_viewport.width * 0.10)
+                            .right(usage_viewport.width * 0.10)
+                            .bottom(usage_viewport.height * 0.05)
+                            .occlude()
+                            // 面板内按下不冒泡到遮罩(原版 `Modal.tsx:180` 的
+                            // stopPropagation 同款),否则点面板空白处也会关窗
+                            .on_mouse_down(gpui::MouseButton::Left, |_event, _window, cx| {
+                                cx.stop_propagation();
+                            })
+                            // 面板体自己的底色。**别省这一行** —— 少了它面板就是全透明的,
+                            // 背后只剩那层 black/50,终端文字照样一个个看得清。
+                            //
+                            // Windows 上看不出来:根层那张毛玻璃快照垫在面板之下,透出来的是
+                            // 模糊+压暗的画面,勉强能读。但快照走 `PrintWindow` 是 Windows 专有
+                            // (见 `frost` 模块),**非 Windows 上 `frost` 恒为 `None`**,退化成
+                            // 纯 black/50 —— 隔着一层黑纱看锐利的终端正文,读不了。
+                            //
+                            // 用 `bg_overlay` 而不是 `bg_surface` / `bg_elevated`:后两者在外置
+                            // 主题包下会乘 `surface_opacity`(有背景图时要透出图),而浮层叠在任意
+                            // 内容之上,半透明是拿可读性换观感 —— 判据见 `ui::Palette::from_pack`
+                            // 里那一行注释。设置弹窗与 pane 预览 / 分支家族 / 日期选择器四处浮层
+                            // 用的都是它,这里是唯一漏掉的一个。
+                            .bg(ui::bg_overlay())
+                            .rounded(px(6.0))
+                            .border_1()
+                            .border_color(ui::border_default())
+                            .overflow_hidden()
+                            .flex()
+                            .flex_col()
+                            .child(
+                                div()
+                                    .flex()
+                                    .items_center()
+                                    .justify_between()
+                                    .px(px(12.0))
+                                    .py(px(6.0))
+                                    .bg(ui::bg_elevated())
+                                    .child(
+                                        div()
+                                            .text_size(crate::ui::font_px(12.0))
+                                            .text_color(ui::text_primary())
+                                            .child(t("usageStats", "title")),
+                                    )
+                                    .child(
+                                        div()
+                                            .id("usage-close")
+                                            .px(px(6.0))
+                                            .text_color(ui::text_muted())
+                                            .cursor_pointer()
+                                            .hover(|el| el.text_color(ui::color_error()))
+                                            // 走 toggle 而不是直接改标志位 —— 可见性要透给
+                                            // 面板,否则关掉之后自动刷新定时器还在每 5s 跑
+                                            .on_click(cx.listener(|this, _event, window, cx| {
+                                                if this.usage_open {
+                                                    this.toggle_usage(window, cx);
+                                                }
+                                            }))
+                                            .child("×"),
+                                    ),
+                            )
+                            .child(div().flex_1().overflow_hidden().child(panel)),
+                    )
+            });
 
         // 三栏 + 悬浮抽屉的那一层。标题栏之下的**全部**内容都在这里 ——
         // 原版同款(`App.tsx:478` 的 `flex-1 overflow-hidden flex`),抽屉的

--- a/crates/mt-app/src/main.rs
+++ b/crates/mt-app/src/main.rs
@@ -2140,6 +2140,26 @@ fn main() {
         })
         .detach();
 
+        // macOS 的 NSApplication **不随最后一个窗口关闭而退出**(Windows / Linux 的
+        // gpui 会结束事件循环),于是关窗后进程还活着、Dock 里还挂着图标,而点它没有
+        // 任何反应:本仓没注册 `on_reopen`,`menu.rs` 又是右键菜单不是菜单栏,没有
+        // 任何入口能把窗口叫回来 —— 应用变成一个点不开也退不掉的僵尸。
+        //
+        // 收敛成「关窗即退出」而不是重开窗口:`Workspace::new` 吃掉的 `ai_events` 是
+        // 一次性的 `UnboundedReceiver`,重建窗口得先把 AI 事件泵与 Workspace 的生命
+        // 周期解耦;而 `title_bar::finish_close` 的注释(「那条管进程退出,这条管窗口
+        // 关闭」)与关窗确认框的措辞(「关掉会丢失这些 AI 会话」)本来就是
+        // 「关窗 = 关应用」的语义。
+        //
+        // 只在 macOS 挂:另外两家 gpui 自己就会退,多这一道只会在主力平台上引入变数。
+        #[cfg(target_os = "macos")]
+        cx.on_window_closed(|cx| {
+            if cx.windows().is_empty() {
+                cx.quit();
+            }
+        })
+        .detach();
+
         // 上次退出时的窗口大小/位置/最大化态(存在 layout.db)。没存过 / 存的框
         // 已经不在任何一块屏幕上 → 回落默认居中 1280×800。
         let window_bounds = restore_window_bounds(store.read(cx).window_geometry(), cx);

--- a/crates/mt-app/src/store/pure.rs
+++ b/crates/mt-app/src/store/pure.rs
@@ -317,7 +317,11 @@ const GENERIC_FAMILIES: [&str; 5] = ["monospace", "sans-serif", "serif", "system
 /// 原版把它接在**用户自选字体**后面,这里同样。
 const CJK_FALLBACK_FONTS: [&str; 3] = ["Microsoft YaHei", "PingFang SC", "Noto Sans CJK SC"];
 /// emoji 回退。`TerminalStyle::default()` 里本来就有,自定义字族时别弄丢。
-const EMOJI_FALLBACK: &str = "Segoe UI Emoji";
+///
+/// 与 [`CJK_FALLBACK_FONTS`] 同样**三家并列**:回退表里点不到的名字会被跳过,
+/// 列全比按平台切省事,也让同一串字族配置在三个平台上表现一致。此前只有
+/// `Segoe UI Emoji` 一个,macOS / Linux 上必然落空,终端里的 emoji 无字体可用。
+const EMOJI_FALLBACK_FONTS: [&str; 3] = ["Segoe UI Emoji", "Apple Color Emoji", "Noto Color Emoji"];
 
 /// `config.terminalFontSize` + `terminalFontFamily` → [`TerminalStyle`]。
 ///
@@ -342,7 +346,7 @@ pub fn terminal_style_from(size: f64, family: Option<&str>, ligatures: bool) -> 
         return style;
     }
     style.font_family = families.remove(0).into();
-    for extra in CJK_FALLBACK_FONTS.iter().chain([&EMOJI_FALLBACK]) {
+    for extra in CJK_FALLBACK_FONTS.iter().chain(EMOJI_FALLBACK_FONTS.iter()) {
         if !families.iter().any(|f| f == extra) {
             families.push((*extra).to_string());
         }
@@ -979,7 +983,13 @@ mod tests {
         for cjk in CJK_FALLBACK_FONTS {
             assert!(fallbacks.iter().any(|f| f == cjk), "缺 CJK 回退 {cjk}");
         }
-        assert!(fallbacks.iter().any(|f| f == EMOJI_FALLBACK));
+        // 三家的 emoji 字体都要在:同一串配置换个平台照样画得出 emoji
+        for emoji in EMOJI_FALLBACK_FONTS {
+            assert!(
+                fallbacks.iter().any(|f| f == emoji),
+                "缺 emoji 回退 {emoji}"
+            );
+        }
     }
 
     /// 字族为空 / 只有通用族名时整段回落默认样式(只改字号)。

--- a/crates/mt-ui/src/terminal/element.rs
+++ b/crates/mt-ui/src/terminal/element.rs
@@ -1835,11 +1835,24 @@ const MAX_CURSOR_MOVE_STEPS: usize = 512;
 
 /// 「⌥+点击定位光标」要发的方向键序列。
 ///
-/// 这是个**启发式**:光标最终落在哪由前台程序的行编辑器说了算(readline 与 Ink
-/// 各有各的钳位规则),模拟器能做的只是按行列差把方向键发过去。任何终端里的这个
-/// 功能都是这么实现的 —— shell 和 Ink 类 TUI 自己都不认鼠标定位。
+/// 这是个**启发式**:光标最终落在哪由前台程序的行编辑器说了算(readline /
+/// PSReadLine / Ink 各有各的规则),模拟器能做的只是按列差把方向键发过去。任何终端
+/// 里的这个功能都是这么实现的 —— shell 与 TUI 自己都不认鼠标定位。
 ///
-/// **先竖后横**:行编辑器上下移动时往往把列钳到该行末尾,先竖再横才收得回来。
+/// # 只走同一行
+///
+/// **跨行一律不动**。竖向位移在行编辑器里往往不是「移动光标」而是**召回历史**:
+/// pwsh(PSReadLine)里点上一行,一个 Up 就把当前输入整行换成了历史条目 —— 用户
+/// 想挪个光标,结果正在编辑的内容没了。Terminal.app 的 ⌥+click 有这个坑,这里不抄。
+/// 多行编辑器里的跨行定位留给以后配开关(上游评审实测出的这条,见 PR #59)。
+///
+/// # 对 Ink 类 TUI 不保证
+///
+/// Claude CLI / Codex 这类 Ink 应用把**硬件光标停在输入行末尾**(可见光标块之后),
+/// 而这里的起点取的是 grid 光标 —— 两者对不上,落点会偏。上游评审实测:输入
+/// `abc def` 去点 `d`,字符落到了空格前。只有可见光标恰在行末时才近似可用。
+/// 这不是本实现的缺陷(Terminal.app 在 Claude Code 里同样如此),但别指望它。
+/// shell 提示符(bash / zsh / pwsh)下则是逐格准确的。
 fn cursor_move_bytes(
     from_line: i32,
     from_col: i32,
@@ -1847,20 +1860,19 @@ fn cursor_move_bytes(
     to_col: i32,
     mode: TermMode,
 ) -> Vec<u8> {
-    let dy = to_line - from_line;
+    if from_line != to_line {
+        return Vec::new();
+    }
     let dx = to_col - from_col;
-    let steps = dy.unsigned_abs() as usize + dx.unsigned_abs() as usize;
+    let steps = dx.unsigned_abs() as usize;
     if steps == 0 || steps > MAX_CURSOR_MOVE_STEPS {
         return Vec::new();
     }
-    let mut out = Vec::new();
-    let vertical = if dy > 0 { Arrow::Down } else { Arrow::Up };
-    for _ in 0..dy.abs() {
-        out.extend_from_slice(&arrow_bytes(vertical, mode));
-    }
-    let horizontal = if dx > 0 { Arrow::Right } else { Arrow::Left };
-    for _ in 0..dx.abs() {
-        out.extend_from_slice(&arrow_bytes(horizontal, mode));
+    let dir = if dx > 0 { Arrow::Right } else { Arrow::Left };
+    let seq = arrow_bytes(dir, mode.contains(TermMode::APP_CURSOR));
+    let mut out = Vec::with_capacity(seq.len() * steps);
+    for _ in 0..steps {
+        out.extend_from_slice(&seq);
     }
     out
 }
@@ -2267,7 +2279,7 @@ fn paint_hollow_rect(window: &mut Window, bounds: Bounds<Pixels>, color: Hsla) {
 mod tests {
     use super::*;
 
-    /// ⌥+点击定位光标:同一行只发左右键,先竖后横,零位移不发。
+    /// ⌥+点击定位光标:同一行按列差发左右键,零位移不发。
     #[test]
     fn 点击定位光标合成方向键() {
         let m = TermMode::empty();
@@ -2280,9 +2292,18 @@ mod tests {
         assert_eq!(cursor_move_bytes(0, 5, 0, 3, m), b"\x1b[D\x1b[D".to_vec());
         // 点在光标本身:什么都不发,别让一次点击白白喂 PTY 一个空包
         assert!(cursor_move_bytes(3, 7, 3, 7, m).is_empty());
-        // 先竖后横 —— 行编辑器上下移动会把列钳到行尾,先竖再横才收得回来
-        assert_eq!(cursor_move_bytes(1, 4, 2, 5, m), b"\x1b[B\x1b[C".to_vec());
-        assert_eq!(cursor_move_bytes(2, 4, 1, 3, m), b"\x1b[A\x1b[D".to_vec());
+    }
+
+    /// **跨行一律不动**。竖向位移在行编辑器里往往是召回历史而不是移动光标 ——
+    /// pwsh 里点上一行,一个 Up 就把正在编辑的整行换成历史条目(上游评审实测)。
+    /// 这条钉住「宁可不动也不能毁掉用户正在输入的内容」。
+    #[test]
+    fn 点击定位光标跨行不动() {
+        let m = TermMode::empty();
+        assert!(cursor_move_bytes(1, 4, 2, 5, m).is_empty(), "往下跨行");
+        assert!(cursor_move_bytes(2, 4, 1, 3, m).is_empty(), "往上跨行");
+        // 跨行且同列同样不动
+        assert!(cursor_move_bytes(1, 4, 5, 4, m).is_empty(), "跨行同列");
     }
 
     /// DECCKM(`APP_CURSOR`)下方向键换 SS3 前缀 —— 与 `keystroke_to_bytes` 同一口径,

--- a/crates/mt-ui/src/terminal/element.rs
+++ b/crates/mt-ui/src/terminal/element.rs
@@ -83,6 +83,7 @@ use mt_terminal::{TermSize, TerminalEmulator};
 
 use super::colors;
 use super::damage::{CellSignature, DamageStats, FrameKey, MAX_ZEROWIDTH_CHARS, RowCache, row_signature};
+use super::input::{Arrow, arrow_bytes};
 use super::mouse::{
     GridPos, MouseAction, MouseBtn, MouseMods, WheelDir, alt_screen_scroll_bytes,
     mouse_report_bytes, mouse_reporting_active, prefers_local_handling,
@@ -863,6 +864,31 @@ impl TerminalElement {
                     return;
                 }
                 let display_offset = emulator.with_term(|t| t.grid().display_offset());
+
+                // ⌥+单击:把光标挪到点中的格子。判定与合成见 [`cursor_move_bytes`]。
+                //
+                // **修饰键不能省**:裸左键是拖选区的起手式,两者抢同一个手势。
+                // Terminal.app 同样挂在 ⌥+click 上,这里照它。
+                //
+                // 只在**没滚动回看**时生效:滚上去之后视口行号与光标所在的 grid 行
+                // 不是一回事,差值算出来会把光标带到莫名其妙的地方。
+                if event.modifiers.alt
+                    && event.click_count == 1
+                    && display_offset == 0
+                    && let Some(on_input) = on_input.as_ref()
+                {
+                    let (cur_line, cur_col) = emulator.with_term(|t| {
+                        let p = t.grid().cursor.point;
+                        (p.line.0, p.column.0 as i32)
+                    });
+                    let payload =
+                        cursor_move_bytes(cur_line, cur_col, row as i32, col as i32, mode);
+                    if !payload.is_empty() {
+                        on_input(&payload, window, cx);
+                    }
+                    return;
+                }
+
                 let ty = match event.click_count {
                     1 => SelectionType::Simple,
                     2 => SelectionType::Semantic,
@@ -1801,6 +1827,44 @@ fn width_fits_columns(shaped: Pixels, cell_width: Pixels, cols: usize) -> bool {
     (f(shaped) - f(cell_width) * cols as f32).abs() <= LIGATURE_WIDTH_SLACK
 }
 
+/// 「⌥+点击定位光标」一次最多合成多少个方向键。
+///
+/// 手滑点到几千列开外时别把 PTY 灌爆:超了就整个不动,比走一半停下强
+/// (走一半的结果既不是用户要的位置,又没法撤销)。
+const MAX_CURSOR_MOVE_STEPS: usize = 512;
+
+/// 「⌥+点击定位光标」要发的方向键序列。
+///
+/// 这是个**启发式**:光标最终落在哪由前台程序的行编辑器说了算(readline 与 Ink
+/// 各有各的钳位规则),模拟器能做的只是按行列差把方向键发过去。任何终端里的这个
+/// 功能都是这么实现的 —— shell 和 Ink 类 TUI 自己都不认鼠标定位。
+///
+/// **先竖后横**:行编辑器上下移动时往往把列钳到该行末尾,先竖再横才收得回来。
+fn cursor_move_bytes(
+    from_line: i32,
+    from_col: i32,
+    to_line: i32,
+    to_col: i32,
+    mode: TermMode,
+) -> Vec<u8> {
+    let dy = to_line - from_line;
+    let dx = to_col - from_col;
+    let steps = dy.unsigned_abs() as usize + dx.unsigned_abs() as usize;
+    if steps == 0 || steps > MAX_CURSOR_MOVE_STEPS {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let vertical = if dy > 0 { Arrow::Down } else { Arrow::Up };
+    for _ in 0..dy.abs() {
+        out.extend_from_slice(&arrow_bytes(vertical, mode));
+    }
+    let horizontal = if dx > 0 { Arrow::Right } else { Arrow::Left };
+    for _ in 0..dx.abs() {
+        out.extend_from_slice(&arrow_bytes(horizontal, mode));
+    }
+    out
+}
+
 /// 把一行解析好的格子变成可绘制产物。**几何全部相对行首**。
 #[allow(clippy::too_many_arguments)]
 fn build_row(
@@ -2202,6 +2266,44 @@ fn paint_hollow_rect(window: &mut Window, bounds: Bounds<Pixels>, color: Hsla) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// ⌥+点击定位光标:同一行只发左右键,先竖后横,零位移不发。
+    #[test]
+    fn 点击定位光标合成方向键() {
+        let m = TermMode::empty();
+        // 同行右移 3 格
+        assert_eq!(
+            cursor_move_bytes(0, 2, 0, 5, m),
+            b"\x1b[C\x1b[C\x1b[C".to_vec()
+        );
+        // 同行左移 2 格
+        assert_eq!(cursor_move_bytes(0, 5, 0, 3, m), b"\x1b[D\x1b[D".to_vec());
+        // 点在光标本身:什么都不发,别让一次点击白白喂 PTY 一个空包
+        assert!(cursor_move_bytes(3, 7, 3, 7, m).is_empty());
+        // 先竖后横 —— 行编辑器上下移动会把列钳到行尾,先竖再横才收得回来
+        assert_eq!(cursor_move_bytes(1, 4, 2, 5, m), b"\x1b[B\x1b[C".to_vec());
+        assert_eq!(cursor_move_bytes(2, 4, 1, 3, m), b"\x1b[A\x1b[D".to_vec());
+    }
+
+    /// DECCKM(`APP_CURSOR`)下方向键换 SS3 前缀 —— 与 `keystroke_to_bytes` 同一口径,
+    /// 两处若分叉,vim 这类开了应用光标键的程序会收到它不认的序列。
+    #[test]
+    fn 点击定位光标跟随应用光标键模式() {
+        assert_eq!(
+            cursor_move_bytes(0, 0, 0, 2, TermMode::APP_CURSOR),
+            b"\x1bOC\x1bOC".to_vec()
+        );
+    }
+
+    /// 点到几千列开外时整个不动:走一半的结果既不是用户要的位置,又没法撤销。
+    #[test]
+    fn 点击定位光标超出步数上限即放弃() {
+        let far = MAX_CURSOR_MOVE_STEPS as i32 + 1;
+        assert!(cursor_move_bytes(0, 0, 0, far, TermMode::empty()).is_empty());
+        // 上限本身要放行
+        let at_limit = cursor_move_bytes(0, 0, 0, MAX_CURSOR_MOVE_STEPS as i32, TermMode::empty());
+        assert_eq!(at_limit.len(), MAX_CURSOR_MOVE_STEPS * 3);
+    }
 
     /// 闪烁行的 grid 绝对行号 → 屏幕行:`row = line + display_offset`。
     /// 视口顶在最新内容时(offset = 0),正数行号就是屏幕行本身。

--- a/crates/mt-ui/src/terminal/input.rs
+++ b/crates/mt-ui/src/terminal/input.rs
@@ -74,12 +74,10 @@ pub fn keystroke_to_bytes(keystroke: &Keystroke, mode: TermMode) -> Option<Vec<u
         return None;
     }
 
-    // 方向键 / Home / End 在 DECCKM(APP_CURSOR)下换 SS3 前缀。
+    // 方向键 / Home / End 在 DECCKM(APP_CURSOR)下换 SS3 前缀。编码收口在
+    // [`cursor_key_bytes`],这里只是把 `app_cursor` 绑进去。
     let app_cursor = mode.contains(TermMode::APP_CURSOR);
-    let cursor_seq = |final_byte: char| -> Vec<u8> {
-        let prefix = if app_cursor { "\x1bO" } else { "\x1b[" };
-        format!("{prefix}{final_byte}").into_bytes()
-    };
+    let cursor_seq = |final_byte: char| -> Vec<u8> { cursor_key_bytes(final_byte, app_cursor) };
     // 带修饰键的方向键走 CSI 1;<mod><final>。
     let modifier_param = modifier_param(m.shift, m.alt, m.control);
     let cursor_seq_mod = |final_byte: char| -> Vec<u8> {
@@ -221,24 +219,27 @@ pub enum Arrow {
     Right,
 }
 
-/// 一个**无修饰**方向键的字节序列(DECCKM / `APP_CURSOR` 下换 SS3 前缀)。
+/// 光标键序列的编码:CSI `ESC [ <final>`,DECCKM(`APP_CURSOR`)下换 SS3
+/// `ESC O <final>`。方向键与 Home / End 共用这一条规则。
 ///
-/// 「⌥+点击定位光标」按行列差值连发方向键,那条路手上没有 `Keystroke` 可喂给
-/// [`keystroke_to_bytes`],于是把里面那一小段编码抽出来共用 —— 两处各写一份,
-/// 迟早在 DECCKM 这种细节上分叉。
-pub fn arrow_bytes(dir: Arrow, mode: TermMode) -> Vec<u8> {
-    let prefix = if mode.contains(TermMode::APP_CURSOR) {
-        "\x1bO"
-    } else {
-        "\x1b["
-    };
+/// **全仓只有这一处知道 SS3 那件事**。此前它散在三个地方各写一份
+/// (`keystroke_to_bytes` 的 `cursor_seq` 闭包、[`arrow_bytes`]、
+/// [`super::mouse::alt_screen_scroll_bytes`] 的四个硬编码字面量),
+/// 谁改了 DECCKM 的判据都不会波及另外两处 —— 收口到这里。
+pub fn cursor_key_bytes(final_byte: char, app_cursor: bool) -> Vec<u8> {
+    let prefix = if app_cursor { "\x1bO" } else { "\x1b[" };
+    format!("{prefix}{final_byte}").into_bytes()
+}
+
+/// 一个**无修饰**方向键的字节序列。编码规则见 [`cursor_key_bytes`]。
+pub fn arrow_bytes(dir: Arrow, app_cursor: bool) -> Vec<u8> {
     let final_byte = match dir {
         Arrow::Up => 'A',
         Arrow::Down => 'B',
         Arrow::Right => 'C',
         Arrow::Left => 'D',
     };
-    format!("{prefix}{final_byte}").into_bytes()
+    cursor_key_bytes(final_byte, app_cursor)
 }
 
 /// 粘贴文本 → PTY 字节。开了 bracketed paste 就包上 `ESC[200~ … ESC[201~`。
@@ -284,6 +285,41 @@ mod tests {
             keystroke_to_bytes(&k, TermMode::APP_CURSOR).unwrap(),
             b"\x1bOA".to_vec()
         );
+    }
+
+    /// 方向键的编码只有 [`cursor_key_bytes`] 一处知道 SS3 那件事,三个调用方必须
+    /// 逐字节一致。此前它散成三份(这里的 `cursor_seq` 闭包、[`arrow_bytes`]、
+    /// `mouse::alt_screen_scroll_bytes` 的硬编码字面量),改一处波及不到另两处 ——
+    /// 上游评审(PR #59)指出过。这条把三条路交叉钉死,DECCKM 两态都比。
+    #[test]
+    fn 三处方向键编码逐字节一致() {
+        for (app_cursor, mode) in [(false, TermMode::empty()), (true, TermMode::APP_CURSOR)] {
+            for (name, dir, expect_tail) in [
+                ("up", Arrow::Up, 'A'),
+                ("down", Arrow::Down, 'B'),
+                ("right", Arrow::Right, 'C'),
+                ("left", Arrow::Left, 'D'),
+            ] {
+                let want = cursor_key_bytes(expect_tail, app_cursor);
+                assert_eq!(arrow_bytes(dir, app_cursor), want, "arrow_bytes {name}");
+                assert_eq!(
+                    keystroke_to_bytes(&key(name, Modifiers::default()), mode).unwrap(),
+                    want,
+                    "keystroke_to_bytes {name} (app_cursor={app_cursor})"
+                );
+            }
+            // 滚轮那条路只用上下两个方向
+            assert_eq!(
+                crate::terminal::mouse::alt_screen_scroll_bytes(1, app_cursor),
+                cursor_key_bytes('A', app_cursor),
+                "alt_screen 上滚 (app_cursor={app_cursor})"
+            );
+            assert_eq!(
+                crate::terminal::mouse::alt_screen_scroll_bytes(-1, app_cursor),
+                cursor_key_bytes('B', app_cursor),
+                "alt_screen 下滚 (app_cursor={app_cursor})"
+            );
+        }
     }
 
     #[test]

--- a/crates/mt-ui/src/terminal/input.rs
+++ b/crates/mt-ui/src/terminal/input.rs
@@ -212,6 +212,35 @@ fn control_code(key: &str) -> Option<Vec<u8>> {
     Some(vec![byte])
 }
 
+/// 一个方向键。见 [`arrow_bytes`]。
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Arrow {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+/// 一个**无修饰**方向键的字节序列(DECCKM / `APP_CURSOR` 下换 SS3 前缀)。
+///
+/// 「⌥+点击定位光标」按行列差值连发方向键,那条路手上没有 `Keystroke` 可喂给
+/// [`keystroke_to_bytes`],于是把里面那一小段编码抽出来共用 —— 两处各写一份,
+/// 迟早在 DECCKM 这种细节上分叉。
+pub fn arrow_bytes(dir: Arrow, mode: TermMode) -> Vec<u8> {
+    let prefix = if mode.contains(TermMode::APP_CURSOR) {
+        "\x1bO"
+    } else {
+        "\x1b["
+    };
+    let final_byte = match dir {
+        Arrow::Up => 'A',
+        Arrow::Down => 'B',
+        Arrow::Right => 'C',
+        Arrow::Left => 'D',
+    };
+    format!("{prefix}{final_byte}").into_bytes()
+}
+
 /// 粘贴文本 → PTY 字节。开了 bracketed paste 就包上 `ESC[200~ … ESC[201~`。
 ///
 /// 无论哪种模式都要先把 `\r\n` / `\n` 归一成 `\r`:PTY 那头把 `\n` 当作

--- a/crates/mt-ui/src/terminal/mouse.rs
+++ b/crates/mt-ui/src/terminal/mouse.rs
@@ -45,6 +45,8 @@
 
 use alacritty_terminal::term::TermMode;
 
+use super::input::{Arrow, arrow_bytes};
+
 /// 鼠标按键。`Other` 是 4 号以上的侧键（bit 7 那一族）。
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MouseBtn {
@@ -233,16 +235,14 @@ fn push_utf8(out: &mut Vec<u8>, value: u32) {
 /// alt screen 下滚轮的等价按键序列（没有回看缓冲，滚轮当上下方向键使）。
 ///
 /// 这是 xterm 的老约定，`less` / `vim` / `man` 全都靠它。`app_cursor` 是 DECCKM。
+/// 序列本身走 [`super::input::arrow_bytes`] —— 此前这里硬编码着四个字面量，
+/// 与 `keystroke_to_bytes` 各写一份，改 DECCKM 判据时波及不到对方。
 pub fn alt_screen_scroll_bytes(lines: i32, app_cursor: bool) -> Vec<u8> {
-    let seq: &[u8] = match (lines > 0, app_cursor) {
-        (true, false) => b"\x1b[A",
-        (true, true) => b"\x1bOA",
-        (false, false) => b"\x1b[B",
-        (false, true) => b"\x1bOB",
-    };
+    let dir = if lines > 0 { Arrow::Up } else { Arrow::Down };
+    let seq = arrow_bytes(dir, app_cursor);
     let mut out = Vec::with_capacity(seq.len() * lines.unsigned_abs() as usize);
     for _ in 0..lines.unsigned_abs() {
-        out.extend_from_slice(seq);
+        out.extend_from_slice(&seq);
     }
     out
 }

--- a/crates/mt-ui/src/terminal/theme.rs
+++ b/crates/mt-ui/src/terminal/theme.rs
@@ -121,22 +121,54 @@ pub struct TerminalStyle {
     pub ligatures: bool,
 }
 
+/// 默认等宽字族栈(主字体 + 回退),按平台选。
+///
+/// **主字体必须随平台走**:`font_fallbacks` 只在主字体缺**字形**时才往下找,
+/// 主字体族本身不存在时 gpui 不会顺着回退表试,而是直接落到平台 UI 字体 ——
+/// 那是比例字体,[`super::TerminalElement`] 的逐列对齐当场失效(症状是每个字形
+/// 钉在列格左沿、窄字母后面拖一片空白)。原先三平台共用 Windows 那一套,
+/// macOS / Linux 上五个名字全落空,没手填字族就是开箱即坏。
+///
+/// 取值一律挑该平台**开箱即有**的:Windows 11 的 Cascadia Mono、macOS 自带的
+/// Menlo(SF Mono 没被登记成 CoreText family,点名点不到)、主流发行版随
+/// fontconfig 一起装的 DejaVu Sans Mono。
+fn default_font_stack() -> (&'static str, &'static [&'static str]) {
+    if cfg!(target_os = "macos") {
+        ("Menlo", &["Monaco", "PingFang SC", "Apple Color Emoji"])
+    } else if cfg!(target_os = "linux") {
+        (
+            "DejaVu Sans Mono",
+            &[
+                "Noto Sans Mono",
+                "Liberation Mono",
+                "Noto Sans CJK SC",
+                "Noto Color Emoji",
+            ],
+        )
+    } else {
+        (
+            "Cascadia Mono",
+            &[
+                "Consolas",
+                "JetBrains Mono",
+                "Microsoft YaHei",
+                "Segoe UI Emoji",
+            ],
+        )
+    }
+}
+
 impl Default for TerminalStyle {
     fn default() -> Self {
+        let (family, fallbacks) = default_font_stack();
         Self {
-            // Windows 11 自带;Cascadia Mono 缺席时由 gpui 的 fallback 栈兜底。
-            font_family: "Cascadia Mono".into(),
-            font_fallbacks: vec![
-                "Consolas".into(),
-                "JetBrains Mono".into(),
-                "Microsoft YaHei".into(),
-                "Segoe UI Emoji".into(),
-            ],
+            font_family: family.into(),
+            font_fallbacks: fallbacks.iter().map(|f| SharedString::from(*f)).collect(),
             font_size: px(14.0),
             line_height: 1.3,
-            // 默认关:默认字族 Cascadia **Mono** 本来就是去连字版,开了也没东西可连,
-            // 徒增一次总宽校验。要连字的用户得先把字族换成 Cascadia Code 这类带
-            // `calt` 表的字体 —— 设置页那行提示说的就是这件事。
+            // 默认关:三家的默认字族都是去连字版,开了也没东西可连,徒增一次总宽
+            // 校验。要连字的用户得先把字族换成 Cascadia Code 这类带 `calt` 表的
+            // 字体 —— 设置页那行提示说的就是这件事。
             ligatures: false,
         }
     }
@@ -200,7 +232,7 @@ mod tests {
     #[test]
     fn 连字开关只切_calt() {
         let mut style = TerminalStyle::default();
-        assert!(!style.ligatures, "默认关:默认字族 Cascadia Mono 是去连字版");
+        assert!(!style.ligatures, "默认关:三家默认字族都是去连字版");
         assert_eq!(style.font().features.is_calt_enabled(), Some(false));
 
         style.ligatures = true;
@@ -234,6 +266,30 @@ mod tests {
 
         // 同一份样式连问两次必须一模一样(命中缓存那条路)
         assert_eq!(style.font(), style.font());
+    }
+
+    /// 默认字族栈必须是**本平台**开箱即有的等宽字体。
+    ///
+    /// 曾经三平台共用 Windows 那一套(Cascadia Mono + Consolas / JetBrains Mono /
+    /// Microsoft YaHei / Segoe UI Emoji),macOS 与 Linux 上五个名字一个都点不到。
+    /// 主字体族点不到时 gpui 不会顺着回退表试,而是直接回落平台 UI 字体,于是
+    /// 终端拿比例字体去做逐列对齐 —— 没手填字族的 mac 用户开箱就撞上。
+    /// 这条钉住三家各自的主字体与 emoji 回退,别再退回单一平台。
+    #[test]
+    fn 默认字族栈按平台选() {
+        let style = TerminalStyle::default();
+        let (family, emoji) = if cfg!(target_os = "macos") {
+            ("Menlo", "Apple Color Emoji")
+        } else if cfg!(target_os = "linux") {
+            ("DejaVu Sans Mono", "Noto Color Emoji")
+        } else {
+            ("Cascadia Mono", "Segoe UI Emoji")
+        };
+        assert_eq!(style.font_family.as_ref(), family);
+        assert!(
+            style.font_fallbacks.iter().any(|f| f.as_ref() == emoji),
+            "缺本平台 emoji 回退 {emoji}"
+        );
     }
 }
 

--- a/crates/mt-ui/src/terminal/view.rs
+++ b/crates/mt-ui/src/terminal/view.rs
@@ -635,7 +635,14 @@ impl TerminalView {
         // ⚠️ 必须一并认 `platform`:macOS 把 ⌘ 报在 `platform` 位而不是 `control`,
         // 只判 `control` 的话这个分支在 mac 上永远进不去 —— 而设置页恰恰把这条
         // 显示成 ⌘⇧V(`hotkeys.rs::combo_label` 在 mac 上渲染 ⌘),显示与实际对不上。
-        // 判据与 [`smart_key_action`] 保持同一口径。
+        // 判据与 [`smart_key_action`] 保持同一口径(那边本来就是 `control || platform`)。
+        //
+        // **副作用如实记:Windows 上 Win+Shift+C / Win+Shift+V 也会被这里接管**
+        // —— gpui 的 Windows 后端把 Win 键报在 `platform` 位(`events.rs`),上游评审
+        // 真机实测到了(PR #59)。刻意不用 `cfg!(target_os = "macos")` 闸住:
+        // ① `smart_key_action` 那条路**本来**就把 `platform` 与 `control` 同权,
+        //    这里闸住反而让两条路的判据分叉;② Win+Shift+V 没有系统绑定,多一条
+        //    粘贴入口无害。要严格守住「Windows 逐字不变」就在这里加 cfg 闸门。
         if (mods.control || mods.platform) && mods.shift {
             match keystroke.key.as_str() {
                 "c" => {

--- a/crates/mt-ui/src/terminal/view.rs
+++ b/crates/mt-ui/src/terminal/view.rs
@@ -289,13 +289,24 @@ pub(crate) enum SmartAction {
 /// 逐条照抄原版 `attachCustomKeyEventHandler` 的第三段:
 /// `mod = ctrlKey || metaKey`,且**不带 Shift / Alt**;`KeyC` 有选区才接管
 /// (没选区 `return true` = 透传 SIGINT,这是这个功能的全部意义),`KeyV` 一律接管。
+///
+/// # macOS 上 ⌘ 不受 `enabled` 管
+///
+/// 这个开关存在的理由是 Windows / Linux 上 ^C 必须发 SIGINT、^V 是 literal-next,
+/// 拿它们当复制粘贴要用户自己权衡。**macOS 没有这个冲突** —— ⌘ 根本不是终端修饰键,
+/// 中断走的是物理 Control+C,两个键位互不相干。Terminal.app / iTerm2 / Ghostty /
+/// WezTerm 一律 ⌘C / ⌘V 无条件生效,这里对齐。
+///
+/// 只放行 `platform`,不动 `control`:Windows 上 `platform` 是 Win 键(Win+V 是系统
+/// 剪贴板历史),那边维持原样由开关管。
 pub(crate) fn smart_key_action(
     enabled: bool,
     mods: &gpui::Modifiers,
     key: &str,
     has_selection: bool,
 ) -> SmartAction {
-    if !enabled || !(mods.control || mods.platform) || mods.shift || mods.alt {
+    let mac_cmd = cfg!(target_os = "macos") && mods.platform;
+    if (!enabled && !mac_cmd) || !(mods.control || mods.platform) || mods.shift || mods.alt {
         return SmartAction::PassThrough;
     }
     match key {
@@ -619,8 +630,13 @@ impl TerminalView {
             return;
         }
 
-        // 应用层快捷键:Ctrl+Shift+C / Ctrl+Shift+V。
-        if mods.control && mods.shift {
+        // 应用层快捷键:Ctrl+Shift+C / Ctrl+Shift+V(macOS 上是 ⌘⇧C / ⌘⇧V)。
+        //
+        // ⚠️ 必须一并认 `platform`:macOS 把 ⌘ 报在 `platform` 位而不是 `control`,
+        // 只判 `control` 的话这个分支在 mac 上永远进不去 —— 而设置页恰恰把这条
+        // 显示成 ⌘⇧V(`hotkeys.rs::combo_label` 在 mac 上渲染 ⌘),显示与实际对不上。
+        // 判据与 [`smart_key_action`] 保持同一口径。
+        if (mods.control || mods.platform) && mods.shift {
             match keystroke.key.as_str() {
                 "c" => {
                     self.copy_selection(cx);
@@ -917,6 +933,33 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(smart_key_action(true, &cmd, "v", false), SmartAction::Paste);
+    }
+
+    /// macOS 上 ⌘C / ⌘V **不受开关管**:那个开关是为 Windows / Linux 的 ^C/^V 冲突
+    /// 设的,而 mac 上 ⌘ 根本不是终端修饰键、中断走物理 Control+C,没有冲突可权衡。
+    /// 曾经开关默认关着 + Ctrl+Shift 分支漏判 `platform`,导致 mac 上 ⌘V 与 ⌘⇧V
+    /// **双双失效**、只剩右键菜单能粘贴。这条钉住不要退回去。
+    ///
+    /// `control` 那一路不放行:Windows 的 `platform` 是 Win 键(Win+V 是系统剪贴板
+    /// 历史),行为仍由开关决定 —— 所以断言按平台分叉。
+    #[test]
+    fn mac_的_cmd_不受智能开关管() {
+        let cmd = Modifiers {
+            platform: true,
+            ..Default::default()
+        };
+        let expected = if cfg!(target_os = "macos") {
+            SmartAction::Paste
+        } else {
+            SmartAction::PassThrough
+        };
+        assert_eq!(smart_key_action(false, &cmd, "v", false), expected);
+
+        // 关着的 Ctrl 三家一致:照发 SIGINT / 走老路
+        assert_eq!(
+            smart_key_action(false, &ctrl(), "v", false),
+            SmartAction::PassThrough
+        );
     }
 
     /// 带 Shift / Alt 的组合不归智能键位管:Ctrl+Shift+C/V 是另一条**始终生效**


### PR DESCRIPTION
macOS 上有五处问题，都是移植期遗留、只在这个平台触发，Windows 主力开发时看不见。放在一起提。

我是在自己的 Mac 上用起来撞到的，逐条查到根因后修的。作者若觉得某条取舍不合适，拆开合也行。

> **2026-08-30 更新**：已按评审整改，新增提交 `1ec7105`。两条「应修」都处理了，几条「如实记录」也写进了代码注释与本文，正文中被证伪的说法已就地更正（下文标注了「评审整改后」的地方）。

---

## 1. 默认终端字族栈是纯 Windows 的 → mac / Linux 开箱就是比例字体

`TerminalStyle::default()` 三平台共用 `Cascadia Mono` + `Consolas` / `JetBrains Mono` / `Microsoft YaHei` / `Segoe UI Emoji`。我在 macOS 上用 CoreText 逐个探过，**这五个名字一个都不存在**。

关键在于 **`font_fallbacks` 只管缺字、不管缺字族**：主字体族本身查不到时，gpui 不会顺着回退表往下试，而是直接回落平台 UI 字体——那是比例字体。于是 `TerminalElement` 拿比例字形去做逐列对齐，每个字形钉在 `col × cell_width` 的左沿，窄字母后面拖一大片空白。

只要用户没在设置里手填 `terminalFontFamily`，macOS 上必然撞上。实测截图里字符步进恒定 28px，而字形墨迹宽度在 1–23px 之间乱跳。

顺带一提，`element.rs` 里那条 `report_metrics_once` 的警告其实早就把结论写对了（「多半是这个字体族在本机不存在，被回退成了 UI 字体」），只是它打到 stderr，GUI 用户看不见。

**改法**：新增 `default_font_stack()` 按平台选主字体与回退。

| 平台 | 主字体 | 回退 |
|---|---|---|
| Windows | `Cascadia Mono`（取值逐字未动） | Consolas / JetBrains Mono / Microsoft YaHei / Segoe UI Emoji |
| macOS | `Menlo` | Monaco / PingFang SC / Apple Color Emoji |
| Linux | `DejaVu Sans Mono` | Noto Sans Mono / Liberation Mono / Noto Sans CJK SC / Noto Color Emoji |

mac 选 Menlo 不选 SF Mono：SF Mono 没被登记成 CoreText family，点名点不到。Menlo 读 `hmtx` 实测 `M = i = W = 0.6021`，严格等宽。

同一批还改了 `store/pure.rs` 的 `EMOJI_FALLBACK`——它此前硬编码只有 `Segoe UI Emoji`，mac / Linux 上必然落空，终端里的 emoji 无字体可用。改成与紧邻的 `CJK_FALLBACK_FONTS` 一样三家并列。

## 2. macOS 上终端粘贴的两条键盘通道全断

`view.rs` 的应用层快捷键分支写的是：

```rust
if mods.control && mods.shift {
```

**漏了 `mods.platform`**——macOS 把 ⌘ 报在那一位，所以这个分支在 mac 上永远进不去，⌘⇧V 不工作。而 ⌘V 走的是「智能 Ctrl+C / Ctrl+V」那条路，那个开关默认关着。

结果是 mac 上只剩右键菜单和物理 Control+Shift+V 能粘贴，偏偏设置页把这条**显示成 ⌘⇧V**（`combo_label` 在 mac 上渲染 ⌘），显示与实际对不上。

同文件的 `smart_key_action` 写的是 `mods.control || mods.platform`，说明这个兼容是知道要做的，只是那个分支没跟上。

**改法两处**：

一是分支判据补 `platform`，与 `smart_key_action` 收成同一口径。

二是让 macOS 的 ⌘C / ⌘V 不再受「智能」开关约束。那个开关存在的理由是 Windows / Linux 上 ^C 必须发 SIGINT、^V 是 literal-next，拿它们当复制粘贴需要用户权衡；**macOS 没有这个冲突**——⌘ 根本不是终端修饰键，中断走的是物理 Control+C，两个键位互不相干。Terminal.app / iTerm2 / Ghostty / WezTerm 一律 ⌘C / ⌘V 无条件生效。

只放行 `platform`，`control` 那一路照旧由开关管：Windows 上 `platform` 是 Win 键（Win+V 是系统剪贴板历史），那边行为一点没动。

## 3. 新增 ⌥+单击定位光标

在 Claude CLI / Codex / 普通 shell 里只能靠方向键移动光标，点击不管用。

这不是 bug 而是缺功能，而且**它本来就得由终端模拟器来做**：shell 与 Ink 类 TUI 自己都不认鼠标定位，任何终端里的这个功能都是模拟器侧按行列差合成方向键。Terminal.app 挂在 ⌥+click 上，iTerm2 两种都给。鼠标上报本身（`terminal/mouse.rs`）没有问题。

**改法**：判定下沉成纯函数 `element.rs::cursor_move_bytes`，几处取舍——

- **只走同一行，跨行一律不动**（评审整改后改的，原为「先竖后横」）：竖向位移在行编辑器里往往不是移动光标而是**召回历史**——评审实测 pwsh(PSReadLine)里点上一行，一个 Up 就把当前输入整行换成了历史条目。Terminal.app 的 ⌥+click 有这个坑，这里不抄；多行编辑器的跨行定位留给以后配开关
- **跟随 DECCKM**：`APP_CURSOR` 下换 SS3 前缀。编码收口到新增的 `input.rs::cursor_key_bytes`，`arrow_bytes` 是它的薄包装，`keystroke_to_bytes` 的 `cursor_seq` 闭包与 `mouse::alt_screen_scroll_bytes` 的四个硬编码字面量都改调它（评审指出上一版只是新增函数、并没真收口，等于三份，已整改）
- **零位移不发包**，避免一次点击白喂 PTY 一个空包
- **超 512 步整个放弃**：手滑点到几千列外时走一半的结果既不是用户要的位置，又没法撤销
- **只在 `display_offset == 0` 时生效**：滚动回看之后视口行号与光标所在的 grid 行不是一回事，差值算出来会把光标带到莫名其妙的地方

**不能用裸左键**——那是拖选区的起手式，两者抢同一个手势，所以必须要修饰键闸门。若希望做成 iTerm2 那种「单击即定位」，需要配一个设置开关，这个 PR 没做。

⚠️ **对 Ink 类 TUI 不保证**（评审实测，已写进代码注释）：Claude CLI / Codex 这类 Ink 应用把硬件光标停在输入行**末尾**（可见光标块之后），而起点取的是 grid 光标，两者对不上、落点会偏。这不是本实现的缺陷（Terminal.app 在 Claude Code 里同样如此），但上一版描述里点名了 Claude CLI / Codex，属实误导，特此更正：**shell 提示符（bash / zsh / pwsh）下逐格准确，Ink 类 TUI 不保证**。

## 4. macOS 上关窗后应用变僵尸

点关闭之后，进程还活着、Dock 里还挂着图标，但点图标没有任何反应，窗口再也叫不回来，也退不掉。

关窗走 `title_bar` 的 `window.remove_window()`，窗口被真正销毁。Windows / Linux 上 gpui 随最后一个窗口关闭结束事件循环，而 **macOS 的 NSApplication 不会退出**。点 Dock 图标会触发 `applicationShouldHandleReopen:`，gpui 把它派给 `Application::on_reopen`，但 `main.rs` 只注册了 `on_app_quit`，没有 `on_reopen` 也没有 `on_window_closed`；`menu.rs` 又是右键菜单不是菜单栏，没有任何入口能把窗口叫回来。

**改法**：挂 `cx.on_window_closed`，无窗口时 `cx.quit()`，只在 macOS 生效。

选「关窗即退出」而不是「重开窗口」，两个理由：`Workspace::new` 吃掉的 `ai_events` 是一次性的 `UnboundedReceiver`，重建窗口得先把 AI 事件泵与 Workspace 的生命周期解耦，改动面大得多；而 `title_bar::finish_close` 的注释（「那条管进程退出，这条管窗口关闭」）与关窗确认框的措辞（「关掉会丢失这些 AI 会话」）本来就是「关窗 = 关应用」的语义。

作者若更希望走 Mac 惯例的 reopen，这条可以单独拿掉。

## 5. 用量统计浮层没有自己的底色 → 非 Windows 上透得能看清终端正文

打开统计面板时，面板底下的终端文字一个个看得清清楚楚。

那个浮层容器（`main.rs` 的 `usage_layer`）有圆角、边框、`overflow_hidden`、flex，**唯独没有 `.bg()`**。面板体于是全透明，背后只剩它自己那层 `black/50`。

Windows 上看不出来，是因为根层还垫着一张毛玻璃快照——透过面板看到的是模糊+压暗的画面，勉强能读。但那张快照走 `PrintWindow(PW_RENDERFULLCONTENT)` + GDI，整块实现挂在 `#[cfg(windows)]` 下，`frost` 模块注释里也写明了「捕获失败（非 Windows / GDI 出错）返回 `None`，退回纯 black/50 遮罩」。非 Windows 上 `frost` 恒为 `None`，退化之后就是隔着一层黑纱看**锐利的**终端正文。

不是回归：这个浮层自 `122b5ca` 引入时就没有这一行（同一处却给标题行写了 `bg_elevated`）。

**改法**：补 `.bg(ui::bg_overlay())`。用这个 token 而不是 `bg_surface` / `bg_elevated`，是因为后两者在外置主题包下会乘 `surface_opacity`（有背景图时要透出图），而浮层叠在任意内容之上——半透明是拿可读性换观感，判据就写在 `Palette::from_pack` 的注释里。设置弹窗、pane 预览、分支家族、日期选择器四处浮层用的都是它，统计面板是唯一漏掉的一个，这下口径齐了。

### 附带的排版提交

`let usage_layer = self.usage_panel.clone().filter(..).map(..)` 那行本来就不是 rustfmt-clean，rustfmt 想把它拆成多行链、连带整块缩进 +4。以前那个 hunk 整体落在改动行之外，CI 的「只拦改动行」门禁忽略它；往块里插了 `.bg()` 之后 hunk 与改动行相交，门禁就拦下了。

所以单独补了一个排版提交。它 92 增 88 删看着唬人，但 `git diff -w` 只有 5 增 1 删——唯一的非空白改动就是那行链式调用拆行，其余全是缩进。**故意与功能改动分开成两个提交**，免得真正的那一行淹在缩进里不好审。

---

## 测试

新增 8 例单测：`cursor_move_bytes` 的同行移动 / 先竖后横 / 零位移 / DECCKM / 步数上限，默认字族栈按平台选，⌘ 不受智能开关管（断言按平台分叉），以及原有 CJK 回退用例扩为遍历三个 emoji 名。

`cargo check --workspace --all-targets`、`clippy`、`cargo test --workspace` 在 ubuntu-22.04 上全绿，改动行 rustfmt clean。

**一处要如实说明的验证盲区**：Linux CI 跑不到 `cfg!(target_os = "macos")` 分支里的断言，那些分支只经过编译、没经过断言。我在自己的 Mac 上装了打包产物做过真机验收（粘贴、⌥+点击定位、关窗退出、终端等宽渲染都正常），但那是手工的，不在 CI 里。

Windows 侧我没有环境验证，**感谢评审补上了真机那半边**（`cargo test --workspace` 28 目标 1670 例全绿，含 `cfg(windows)` 侧）。

上一版说「Windows 取值和行为逐字不变」，评审实测证伪了一处：`(control || platform) && shift` 在 Windows 上把 **Win+Shift+C/V 也接管了**（gpui 的 Windows 后端把 Win 键报在 `platform` 位）。按评审倾向**接受这个行为并把注释写实**，理由记进了代码注释：`smart_key_action` 那条路本来就把 `platform` 与 `control` 同权，这里闸住反而让两条路分叉；且 Win+Shift+V 没有系统绑定。注释里也写明了「要严格守住 Windows 不变就在这里加 `cfg` 闸门」，作者若坚持前者，改一行即可。

其余四处仍是 Windows 逐字不变（字族栈那一档、`on_window_closed` 只在 mac 挂、⌥+点击是纯新增路径、统计面板底色见下）。

统计面板底色那条，评审在 Windows 上同一份数据、同一带背景图的主题包前后各截了一张，**面板体肉眼几乎分不出差别**（`panel_alt` 与毛玻璃透出的压暗画面几乎同色），建议直接接受、不必做「只在 `frost` 为 `None` 时补底色」的分叉。照办，没加分叉。
