### PR TITLE
feat: 新建终端菜单接入 AI 启动器 —— 桌面端一键开出跑着 agent 的终端

### DIFF
--- a/crates/mt-app/src/pane_actions.rs
+++ b/crates/mt-app/src/pane_actions.rs
@@ -22,8 +22,10 @@
 //! 灰色补充行里(原版没有这一段,但「哪几个终端会被杀」是关整组时最想知道的)。
 
 use gpui::{App, Entity, Window};
+use mt_config::{AiLauncher, ShellConfig};
 
 use crate::i18n::{t, tr};
+use crate::menu;
 use crate::prompt::Confirm;
 use crate::session_branch::{BranchMenuSegment, branch_menu_segment};
 use crate::store::{AppStore, resolve_fork_cwd};
@@ -32,6 +34,67 @@ use crate::tree::{PaneState, PaneStatus, SplitDirection, SplitNode};
 /// 这个状态算「AI 会话还活着」吗。
 pub fn is_ai_alive(status: PaneStatus) -> bool {
     matches!(status, PaneStatus::AiWorking | PaneStatus::AiIdle)
+}
+
+// === 新建终端菜单 ===
+
+/// 「新建终端」菜单该不该弹出来。
+///
+/// 原判据是 `shells.len() <= 1` —— 只有一个 shell 时直接开,别让单 shell 用户
+/// 每次多点一下(见 `terminal_area::render_leaf_tab_bar` 那处注释)。接入 AI
+/// 启动器后可选项变成两段,判据必须**连启动器一起算**,否则精简过 shell 列表的
+/// 用户永远看不到启动器段。
+pub fn should_show_new_terminal_menu(shell_count: usize, launcher_count: usize) -> bool {
+    shell_count + launcher_count > 1
+}
+
+/// 「新建终端」菜单的条目:shell 段 +(有启动器时)AI 启动器段 +「管理启动器…」。
+///
+/// # 为什么收成一个入口
+///
+/// 新建终端有三条路:tab 栏的 `+`、空态的「+ 新建终端」按钮、终端面板的 `+`。
+/// 三处此前是同一份代码复制三遍,菜单内容一致纯靠人工对齐;加了启动器段之后
+/// 三份各改一遍必然漂移(与本模块开头「关终端必须收成一个入口」同一个理由)。
+///
+/// 落点差异由两个回调表达:前两处开 tab(带/不带锚点),第三处开面板。
+pub fn new_terminal_menu_entries(
+    shells: Vec<ShellConfig>,
+    launchers: Vec<AiLauncher>,
+    on_shell: impl Fn(ShellConfig, &mut Window, &mut App) + Clone + 'static,
+    on_launcher: impl Fn(AiLauncher, &mut Window, &mut App) + Clone + 'static,
+) -> Vec<menu::MenuEntry> {
+    let mut entries: Vec<menu::MenuEntry> = shells
+        .into_iter()
+        .map(|shell| {
+            let on_shell = on_shell.clone();
+            let name = shell.name.clone();
+            menu::item(name, move |window, cx| on_shell(shell.clone(), window, cx))
+        })
+        .collect();
+
+    // 启动器一条都没有时不出这一段(含标题与分隔线)——空标题比没有更难看
+    if !launchers.is_empty() {
+        entries.push(menu::separator());
+        entries.push(menu::MenuEntry::Header(
+            t("terminalArea", "aiLaunchers").into(),
+        ));
+        for launcher in launchers {
+            let on_launcher = on_launcher.clone();
+            let name = launcher.name.clone();
+            entries.push(menu::item(name, move |window, cx| {
+                on_launcher(launcher.clone(), window, cx)
+            }));
+        }
+    }
+
+    // 启动器配置住在「移动端」面板里(它同时是移动端发起会话的名单),
+    // 桌面端用户找不到那个入口 —— 这一条是唯一的指路牌,故**总是**出现。
+    entries.push(menu::separator());
+    entries.push(menu::item(
+        t("terminalArea", "manageLaunchers"),
+        |window, cx| crate::mobile_panel::open(window, cx),
+    ));
+    entries
 }
 
 /// 盘点一组 pane 里活着的 AI 会话,返回它们的显示名(顺序同 tab 顺序)。
@@ -325,6 +388,21 @@ fn confirm_close_group(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// 「只有一个可选项就别弹菜单」那道闸:接入 AI 启动器后必须**连启动器一起算**。
+    /// 只按 shell 数判的话,精简过 shell 列表的用户永远看不到启动器段
+    /// —— 而那正是这次要给他们的入口。
+    #[test]
+    fn single_option_gate_counts_launchers_too() {
+        // 一个 shell、零启动器:只有一条路,直接开(原行为)
+        assert!(!should_show_new_terminal_menu(1, 0));
+        // 一个 shell、一条启动器:有得选了,必须弹
+        assert!(should_show_new_terminal_menu(1, 1));
+        // 多 shell 照旧弹
+        assert!(should_show_new_terminal_menu(2, 0));
+        // 一条 shell 都没有(配置损坏)也不弹:调用方那条分支会回落默认 shell
+        assert!(!should_show_new_terminal_menu(0, 0));
+    }
 
     fn pane(label: &str, status: PaneStatus) -> PaneState {
         let mut p = PaneState::new(label);

--- a/crates/mt-app/src/pane_actions.rs
+++ b/crates/mt-app/src/pane_actions.rs
@@ -92,7 +92,7 @@ pub fn new_terminal_menu_entries(
     entries.push(menu::separator());
     entries.push(menu::item(
         t("terminalArea", "manageLaunchers"),
-        |window, cx| crate::mobile_panel::open(window, cx),
+        crate::mobile_panel::open,
     ));
     entries
 }

--- a/crates/mt-app/src/pane_actions.rs
+++ b/crates/mt-app/src/pane_actions.rs
@@ -78,8 +78,17 @@ pub fn new_terminal_menu_data(
 ///
 /// 原判据是 `shells.len() <= 1` —— 只有一个 shell 时直接开,别让单 shell 用户
 /// 每次多点一下(见 `terminal_area::render_leaf_tab_bar` 那处注释)。接入 AI
-/// 启动器后可选项变成两段,判据必须**连启动器一起算**,否则精简过 shell 列表的
-/// 用户永远看不到启动器段。
+/// 启动器后可选项变成两段,判据必须**连启动器一起算**,否则单 shell 用户永远
+/// 看不到启动器段。
+///
+/// ⚠️ **影响面比字面大**:启动器的读口径(`AppStore::mobile_relay`)在配置整块
+/// 缺失时回落 `Default`,含预置的 Claude / Codex 两条,`launcher_count` 因此
+/// 恒 ≥ 2 —— 除非用户把启动器删光。也就是说**所有**单 shell 用户点「+」从此
+/// 都会弹菜单,而不只是自己精简过 shell 列表的那批。这是有意为之:本次的目的
+/// 就是把启动器这个入口曝光出来,多的那一次点击换来的是「一键开 AI 会话」。
+///
+/// 例外是远程项目 —— [`new_terminal_menu_data`] 对它返回空启动器,
+/// 于是单 shell + 远程项目仍然是点一下直接开。
 pub fn should_show_new_terminal_menu(shell_count: usize, launcher_count: usize) -> bool {
     shell_count + launcher_count > 1
 }
@@ -426,14 +435,17 @@ mod tests {
     use super::*;
 
     /// 「只有一个可选项就别弹菜单」那道闸:接入 AI 启动器后必须**连启动器一起算**。
-    /// 只按 shell 数判的话,精简过 shell 列表的用户永远看不到启动器段
-    /// —— 而那正是这次要给他们的入口。
+    /// 只按 shell 数判的话,单 shell 用户永远看不到启动器段 —— 而那正是这次要给
+    /// 他们的入口。因为启动器读口径缺省含预置两条,实际效果是所有单 shell 用户
+    /// 点「+」都会弹菜单(远程项目除外,那边启动器为空)。
     #[test]
     fn single_option_gate_counts_launchers_too() {
-        // 一个 shell、零启动器:只有一条路,直接开(原行为)
+        // 一个 shell、零启动器:只有一条路,直接开(原行为;也是远程项目的情形)
         assert!(!should_show_new_terminal_menu(1, 0));
         // 一个 shell、一条启动器:有得选了,必须弹
         assert!(should_show_new_terminal_menu(1, 1));
+        // 预置两条启动器是缺省状态 —— 单 shell 用户实际落在这一档
+        assert!(should_show_new_terminal_menu(1, 2));
         // 多 shell 照旧弹
         assert!(should_show_new_terminal_menu(2, 0));
         // 一条 shell 都没有(配置损坏)也不弹:调用方那条分支会回落默认 shell

--- a/crates/mt-app/src/pane_actions.rs
+++ b/crates/mt-app/src/pane_actions.rs
@@ -38,6 +38,42 @@ pub fn is_ai_alive(status: PaneStatus) -> bool {
 
 // === 新建终端菜单 ===
 
+/// 这个项目能不能在「新建终端」菜单里出 AI 启动器段。
+///
+/// 远程项目**一律不出**:SSH 项目的 PTY 是 ssh 启动器,启动初期可能停在口令或
+/// host key 确认交互上,**预写的命令会被当口令消费** —— 命令丢失之外,登录本身
+/// 还可能因此失败一次;存了密码的连接则会与 PTY 的密码 autofill 状态机抢同一次
+/// 输入。判据与 `AppStore::hydrate_project` 的自动续接守卫同源(`store/panes.rs`,
+/// 那里对远程项目跳过 resume 预写),也与移动端 `mt_relay::can_start_session`
+/// 把远程项目挡在发起会话之外的口径一致。
+///
+/// WSL 项目**不挡**:本地 PTY 直接起 `wsl.exe`,没有口令交互那一段。移动端连
+/// WSL 根项目一起挡是对话镜像盲发的问题,与桌面端这条路径无关。
+pub fn project_allows_launchers(ssh_connection_id: Option<&str>) -> bool {
+    ssh_connection_id.is_none()
+}
+
+/// 「新建终端」菜单的数据源:shell 列表 + 该项目**可用**的启动器。
+///
+/// 与 [`new_terminal_menu_entries`] 一样收成一处 —— 三处入口各判一次远程守卫
+/// 迟早漏掉一处,而漏掉的那处正好是会把用户 ssh 口令吃掉的那条路。
+/// 项目不存在时按「不给启动器」处置(保守侧)。
+pub fn new_terminal_menu_data(
+    store: &AppStore,
+    project_id: &str,
+) -> (Vec<ShellConfig>, Vec<AiLauncher>) {
+    let shells = store.config().available_shells.clone();
+    let allows = store
+        .project(project_id)
+        .is_some_and(|p| project_allows_launchers(p.ssh_connection_id.as_deref()));
+    let launchers = if allows {
+        store.mobile_relay().launchers
+    } else {
+        Vec::new()
+    };
+    (shells, launchers)
+}
+
 /// 「新建终端」菜单该不该弹出来。
 ///
 /// 原判据是 `shells.len() <= 1` —— 只有一个 shell 时直接开,别让单 shell 用户
@@ -402,6 +438,15 @@ mod tests {
         assert!(should_show_new_terminal_menu(2, 0));
         // 一条 shell 都没有(配置损坏)也不弹:调用方那条分支会回落默认 shell
         assert!(!should_show_new_terminal_menu(0, 0));
+    }
+
+    /// 远程项目不出启动器段:ssh 启动初期停在口令/host key 交互上时,
+    /// 预写的 `{命令}\r` 会被当口令消费 —— 判据与 `hydrate_project` 的自动续接
+    /// 守卫同源。WSL 不挡(本地直接起 wsl.exe,没有那段交互)。
+    #[test]
+    fn launcher_section_hidden_for_remote_projects_only() {
+        assert!(project_allows_launchers(None));
+        assert!(!project_allows_launchers(Some("conn-1")));
     }
 
     fn pane(label: &str, status: PaneStatus) -> PaneState {

--- a/crates/mt-app/src/store/panes.rs
+++ b/crates/mt-app/src/store/panes.rs
@@ -5,7 +5,7 @@
 //! `// === 双击最大化 ===`),段注释随代码走,逻辑一行未改。
 
 use gpui::{AppContext, Context, Window};
-use mt_config::{ProjectConfig, ShellConfig};
+use mt_config::{AiLauncher, ProjectConfig, ShellConfig};
 use mt_pty::PtySpawn;
 use mt_ui::{DwellConfig, TerminalStyle};
 
@@ -36,6 +36,73 @@ impl AppStore {
         cx: &mut Context<Self>,
     ) -> Option<String> {
         self.new_terminal_with_cwd(project_id, shell, anchor_pane_id, None, window, cx)
+    }
+
+    /// 新建一个终端 tab 并按 AI 启动器把 agent 拉起来。
+    ///
+    /// 启动器是 `{名称, shell(可选), 命令}` 的具名条目(见 [`mt_config::AiLauncher`]),
+    /// 桌面端与移动端**共用同一份配置**;这里是桌面端那条触发路径。
+    ///
+    /// 与移动端发起会话(`mobile_relay::MobileRelayBridge::try_start_session`)的区别
+    /// 只在落点与善后:那边刻意用 `append_pane_background` 不抢焦点、要回执、要弹
+    /// 审计 toast;桌面端是人自己点的,照常走 [`new_terminal`] 把焦点带过去,
+    /// 不回执也不弹 toast。**改这里时记得看一眼那边**,两条路径共用启动器语义。
+    ///
+    /// [`new_terminal`]: Self::new_terminal
+    pub fn new_terminal_from_launcher(
+        &mut self,
+        project_id: &str,
+        launcher: &AiLauncher,
+        anchor_pane_id: Option<String>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<String> {
+        // 绑定的 shell 被删掉时退回默认 —— 总比不开好,用户在桌面看得到实情
+        // (判据与移动端那条同一个 `resolve_shell`)
+        let shell = self.resolve_shell(launcher.shell.as_deref())?;
+        let pane_id = self.new_terminal(project_id, Some(shell), anchor_pane_id, window, cx)?;
+        self.rename_pane(project_id, &pane_id, &launcher.name, cx);
+        self.write_launcher_command(project_id, &pane_id, &launcher.command, cx);
+        Some(pane_id)
+    }
+
+    /// 新建一个终端**面板**并按 AI 启动器把 agent 拉起来。
+    /// 与 [`new_terminal_from_launcher`] 同,只是落点是新面板而非当前面板的 tab 栏。
+    ///
+    /// [`new_terminal_from_launcher`]: Self::new_terminal_from_launcher
+    pub fn new_panel_from_launcher(
+        &mut self,
+        project_id: &str,
+        launcher: &AiLauncher,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<String> {
+        let shell = self.resolve_shell(launcher.shell.as_deref())?;
+        let pane_id = self.new_panel(project_id, Some(shell), window, cx)?;
+        self.rename_pane(project_id, &pane_id, &launcher.name, cx);
+        self.write_launcher_command(project_id, &pane_id, &launcher.command, cx);
+        Some(pane_id)
+    }
+
+    /// 把启动器命令连同回车写进 pane。
+    ///
+    /// ⚠️ 必须走 [`write_to_pane`] 而不是裸 PTY 写:AI 会话身份靠**输入检测**建立,
+    /// 只有「往 shell 里敲进启动命令并回车」这条路能让 pane 进入 AI 会话状态。
+    /// 把 AI CLI 当成 PTY 根程序 spawn(`shell -c "claude"`)会绕开检测,拿不到
+    /// 状态徽章与对话镜像 —— 这是 ADR 0002 定下的纪律,别改。
+    ///
+    /// PTY 内核缓冲 stdin,shell 就绪前写入不丢(与移动端发起会话同一时序)。
+    /// 写不进去时**保留 pane**:用户回头能看到它卡在哪。
+    ///
+    /// [`write_to_pane`]: Self::write_to_pane
+    fn write_launcher_command(
+        &mut self,
+        project_id: &str,
+        pane_id: &str,
+        command: &str,
+        cx: &mut Context<Self>,
+    ) {
+        self.write_to_pane(project_id, pane_id, &format!("{command}\r"), cx);
     }
 
     /// 新建终端并指定启动目录。

--- a/crates/mt-app/src/terminal_area.rs
+++ b/crates/mt-app/src/terminal_area.rs
@@ -1910,29 +1910,49 @@ impl TerminalArea {
                 .on_click(cx.listener(move |this, event: &ClickEvent, window, cx| {
                     // 与 tab 同理:别让这一下冒到 tab 栏的「双击空白处最大化」上
                     cx.stop_propagation();
-                    let shells = this.store.read(cx).config().available_shells.clone();
-                    if shells.len() <= 1 {
+                    let (shells, launchers) = {
+                        let store = this.store.read(cx);
+                        (
+                            store.config().available_shells.clone(),
+                            store.mobile_relay().launchers,
+                        )
+                    };
+                    if !pane_actions::should_show_new_terminal_menu(shells.len(), launchers.len()) {
                         this.store.update(cx, |store, cx| {
                             store.new_terminal(&pid_new, None, Some(anchor_new.clone()), window, cx);
                         });
                         return;
                     }
-                    // 无勾选标记、无分隔线,就是一列 shell 名
-                    let entries: Vec<menu::MenuEntry> = shells
-                        .into_iter()
-                        .map(|shell| {
+                    let entries = pane_actions::new_terminal_menu_entries(
+                        shells,
+                        launchers,
+                        {
                             let store = this.store.clone();
                             let (pid, anchor) = (pid_new.clone(), anchor_new.clone());
-                            let name = shell.name.clone();
-                            menu::item(name, move |window, cx| {
-                                let (pid, anchor, shell) =
-                                    (pid.clone(), anchor.clone(), shell.clone());
+                            move |shell, window, cx| {
+                                let (pid, anchor) = (pid.clone(), anchor.clone());
                                 store.update(cx, |store, cx| {
                                     store.new_terminal(&pid, Some(shell), Some(anchor), window, cx);
                                 });
-                            })
-                        })
-                        .collect();
+                            }
+                        },
+                        {
+                            let store = this.store.clone();
+                            let (pid, anchor) = (pid_new.clone(), anchor_new.clone());
+                            move |launcher, window, cx| {
+                                let (pid, anchor) = (pid.clone(), anchor.clone());
+                                store.update(cx, |store, cx| {
+                                    store.new_terminal_from_launcher(
+                                        &pid,
+                                        &launcher,
+                                        Some(anchor),
+                                        window,
+                                        cx,
+                                    );
+                                });
+                            }
+                        },
+                    );
                     menu::show(click_position(event, window), entries, window, cx);
                 }))
                 .child("+"),
@@ -3111,27 +3131,48 @@ impl Render for TerminalArea {
                         // 唯一差别是 anchor:空态没有「当前 pane」可挨着放,传 None
                         // (原版那边也是 `newTerminal(projectId)` 不带 targetPaneId)。
                         .on_click(cx.listener(move |this, event: &ClickEvent, window, cx| {
-                            let shells = this.store.read(cx).config().available_shells.clone();
-                            if shells.len() <= 1 {
+                            let (shells, launchers) = {
+                                let store = this.store.read(cx);
+                                (
+                                    store.config().available_shells.clone(),
+                                    store.mobile_relay().launchers,
+                                )
+                            };
+                            if !pane_actions::should_show_new_terminal_menu(
+                                shells.len(),
+                                launchers.len(),
+                            ) {
                                 this.store.update(cx, |store, cx| {
                                     store.new_terminal(&pid, None, None, window, cx);
                                 });
                                 return;
                             }
-                            let entries: Vec<menu::MenuEntry> = shells
-                                .into_iter()
-                                .map(|shell| {
+                            let entries = pane_actions::new_terminal_menu_entries(
+                                shells,
+                                launchers,
+                                {
                                     let store = this.store.clone();
                                     let pid = pid.clone();
-                                    let name = shell.name.clone();
-                                    menu::item(name, move |window, cx| {
-                                        let (pid, shell) = (pid.clone(), shell.clone());
+                                    move |shell, window, cx| {
+                                        let pid = pid.clone();
                                         store.update(cx, |store, cx| {
                                             store.new_terminal(&pid, Some(shell), None, window, cx);
                                         });
-                                    })
-                                })
-                                .collect();
+                                    }
+                                },
+                                {
+                                    let store = this.store.clone();
+                                    let pid = pid.clone();
+                                    move |launcher, window, cx| {
+                                        let pid = pid.clone();
+                                        store.update(cx, |store, cx| {
+                                            store.new_terminal_from_launcher(
+                                                &pid, &launcher, None, window, cx,
+                                            );
+                                        });
+                                    }
+                                },
+                            );
                             menu::show(click_position(event, window), entries, window, cx);
                         }))
                         .child(format!("+ {}", t("terminalArea", "newTerminal"))),

--- a/crates/mt-app/src/terminal_area.rs
+++ b/crates/mt-app/src/terminal_area.rs
@@ -1910,16 +1910,17 @@ impl TerminalArea {
                 .on_click(cx.listener(move |this, event: &ClickEvent, window, cx| {
                     // 与 tab 同理:别让这一下冒到 tab 栏的「双击空白处最大化」上
                     cx.stop_propagation();
-                    let (shells, launchers) = {
-                        let store = this.store.read(cx);
-                        (
-                            store.config().available_shells.clone(),
-                            store.mobile_relay().launchers,
-                        )
-                    };
+                    let (shells, launchers) =
+                        pane_actions::new_terminal_menu_data(this.store.read(cx), &pid_new);
                     if !pane_actions::should_show_new_terminal_menu(shells.len(), launchers.len()) {
                         this.store.update(cx, |store, cx| {
-                            store.new_terminal(&pid_new, None, Some(anchor_new.clone()), window, cx);
+                            store.new_terminal(
+                                &pid_new,
+                                None,
+                                Some(anchor_new.clone()),
+                                window,
+                                cx,
+                            );
                         });
                         return;
                     }
@@ -3131,13 +3132,8 @@ impl Render for TerminalArea {
                         // 唯一差别是 anchor:空态没有「当前 pane」可挨着放,传 None
                         // (原版那边也是 `newTerminal(projectId)` 不带 targetPaneId)。
                         .on_click(cx.listener(move |this, event: &ClickEvent, window, cx| {
-                            let (shells, launchers) = {
-                                let store = this.store.read(cx);
-                                (
-                                    store.config().available_shells.clone(),
-                                    store.mobile_relay().launchers,
-                                )
-                            };
+                            let (shells, launchers) =
+                                pane_actions::new_terminal_menu_data(this.store.read(cx), &pid);
                             if !pane_actions::should_show_new_terminal_menu(
                                 shells.len(),
                                 launchers.len(),

--- a/crates/mt-app/src/terminals_panel.rs
+++ b/crates/mt-app/src/terminals_panel.rs
@@ -261,27 +261,43 @@ impl TerminalsPanel {
                 let Some(pid) = this.store.read(cx).active_project_id.clone() else {
                     return;
                 };
-                let shells = this.store.read(cx).config().available_shells.clone();
-                if shells.len() <= 1 {
+                let (shells, launchers) = {
+                    let store = this.store.read(cx);
+                    (
+                        store.config().available_shells.clone(),
+                        store.mobile_relay().launchers,
+                    )
+                };
+                if !pane_actions::should_show_new_terminal_menu(shells.len(), launchers.len()) {
                     this.store.update(cx, |store, cx| {
                         store.new_panel(&pid, None, window, cx);
                     });
                     return;
                 }
-                let entries: Vec<menu::MenuEntry> = shells
-                    .into_iter()
-                    .map(|shell| {
+                let entries = pane_actions::new_terminal_menu_entries(
+                    shells,
+                    launchers,
+                    {
                         let store = this.store.clone();
                         let pid = pid.clone();
-                        let name = shell.name.clone();
-                        menu::item(name, move |window, cx| {
-                            let (pid, shell) = (pid.clone(), shell.clone());
+                        move |shell, window, cx| {
+                            let pid = pid.clone();
                             store.update(cx, |store, cx| {
                                 store.new_panel(&pid, Some(shell), window, cx);
                             });
-                        })
-                    })
-                    .collect();
+                        }
+                    },
+                    {
+                        let store = this.store.clone();
+                        let pid = pid.clone();
+                        move |launcher, window, cx| {
+                            let pid = pid.clone();
+                            store.update(cx, |store, cx| {
+                                store.new_panel_from_launcher(&pid, &launcher, window, cx);
+                            });
+                        }
+                    },
+                );
                 menu::show(click_position(event, window), entries, window, cx);
             }))
     }

--- a/crates/mt-app/src/terminals_panel.rs
+++ b/crates/mt-app/src/terminals_panel.rs
@@ -261,13 +261,8 @@ impl TerminalsPanel {
                 let Some(pid) = this.store.read(cx).active_project_id.clone() else {
                     return;
                 };
-                let (shells, launchers) = {
-                    let store = this.store.read(cx);
-                    (
-                        store.config().available_shells.clone(),
-                        store.mobile_relay().launchers,
-                    )
-                };
+                let (shells, launchers) =
+                    pane_actions::new_terminal_menu_data(this.store.read(cx), &pid);
                 if !pane_actions::should_show_new_terminal_menu(shells.len(), launchers.len()) {
                     this.store.update(cx, |store, cx| {
                         store.new_panel(&pid, None, window, cx);

--- a/crates/mt-i18n/locales/terminalArea.ts
+++ b/crates/mt-i18n/locales/terminalArea.ts
@@ -9,6 +9,8 @@ export const terminalArea = {
     newPanel: "新建终端面板",
     renamePanel: "重命名面板",
     closePanel: "关闭面板",
+    aiLaunchers: "AI 启动器",
+    manageLaunchers: "管理启动器…",
   },
   en: {
     terminal: "Terminal",
@@ -20,5 +22,7 @@ export const terminalArea = {
     newPanel: "New terminal panel",
     renamePanel: "Rename panel",
     closePanel: "Close panel",
+    aiLaunchers: "AI Launchers",
+    manageLaunchers: "Manage launchers…",
   },
 } as const;

--- a/crates/mt-i18n/src/dict.rs
+++ b/crates/mt-i18n/src/dict.rs
@@ -12,9 +12,9 @@ use crate::Namespace;
 /// 命名空间总数（生成器对账用，测试断言防漂移）
 pub const NAMESPACE_COUNT: usize = 32;
 /// 中文条目总数
-pub const ZH_ENTRY_COUNT: usize = 840;
+pub const ZH_ENTRY_COUNT: usize = 842;
 /// 英文条目总数
-pub const EN_ENTRY_COUNT: usize = 840;
+pub const EN_ENTRY_COUNT: usize = 842;
 
 #[rustfmt::skip]
 static APP_ZH: &[(&str, &str)] = &[
@@ -1625,9 +1625,11 @@ static TERMINAL_EN: &[(&str, &str)] = &[
 
 #[rustfmt::skip]
 static TERMINAL_AREA_ZH: &[(&str, &str)] = &[
+    ("aiLaunchers", "AI 启动器"),
     ("closePanel", "关闭面板"),
     ("emptyHint", "也可以按"),
     ("emptyTitle", "「{project}」还没有打开终端"),
+    ("manageLaunchers", "管理启动器…"),
     ("newPanel", "新建终端面板"),
     ("newTerminal", "新建终端"),
     ("panelN", "面板 {n}"),
@@ -1637,9 +1639,11 @@ static TERMINAL_AREA_ZH: &[(&str, &str)] = &[
 ];
 #[rustfmt::skip]
 static TERMINAL_AREA_EN: &[(&str, &str)] = &[
+    ("aiLaunchers", "AI Launchers"),
     ("closePanel", "Close panel"),
     ("emptyHint", "or press"),
     ("emptyTitle", "No terminal open in \"{project}\""),
+    ("manageLaunchers", "Manage launchers…"),
     ("newPanel", "New terminal panel"),
     ("newTerminal", "New Terminal"),
     ("panelN", "Panel {n}"),

--- a/crates/mt-i18n/tests/consistency.rs
+++ b/crates/mt-i18n/tests/consistency.rs
@@ -81,8 +81,9 @@ use mt_i18n::{
 /// 836 → 839：PR #56 审核整改补远程图片点击加载、远程搜索不支持与下载上下文
 /// 失效三条可见反馈。
 /// 839 → 840：远程文档刷新失败但保留已加载内容时补非阻断警告。
+/// 840 → 842：新建终端菜单接入 AI 启动器段（分组标题 + 「管理启动器…」入口）。
 const EXPECTED_NAMESPACES: usize = 32;
-const EXPECTED_ENTRIES_PER_LANG: usize = 840;
+const EXPECTED_ENTRIES_PER_LANG: usize = 842;
 
 /// TS 侧 `locales/index.ts` 收编的全部命名空间，手抄一份放这里做交叉验证 ——
 /// 只信生成器的话，「某个 ns 文件整体没被读到」这种错会一起漏过去。


### PR DESCRIPTION
## 做了什么

桌面端「新建终端」的三处入口(tab 栏「+」/ 空态按钮 / 终端面板「+」)加入 AI 启动器段,选中即新建 pane 并把启动命令敲进去。

## 为什么

AI 启动器(`{名称, shell?, 命令}`)此前只有移动端能触发(ADR 0002),桌面端要开一个跑着 agent 的终端仍是「新建 tab → 手敲 claude → 回车」三步。启动器配置本身也只藏在「移动端」面板里,桌面用户基本找不到。

## 怎么做的

- **执行内核复用既有语义**:`resolve_shell` → `new_terminal`/`new_panel` → `write_to_pane("{命令}\r")`,与 `session_panel` 的「恢复会话」同一套路。**必须走写入口**而不是把 AI CLI 当 PTY 根程序 spawn —— AI 会话身份靠输入检测建立,这是 ADR 0002 定下的纪律。
- **与移动端 `try_start_session` 的差异只在落点与善后**:那边刻意不抢焦点、要回执、弹审计 toast;桌面端是人自己点的,照常把焦点带过去、不回执也不弹 toast。两处注释互相指认,避免日后改一处漏一处。
- **三处入口收成一处**:此前是同一份代码复制三遍,菜单内容一致纯靠人工对齐;现统一走 `pane_actions::new_terminal_menu_entries`(条目)与 `new_terminal_menu_data`(数据源),落点差异由两个回调表达。
- **菜单结构**:shell 段 → 分隔线 → `AI 启动器` 分组标题 → 启动器 → 分隔线 → `管理启动器…`(跳「移动端」面板)。`MenuEntry::Header` 是现成的,没动 `menu.rs`。

## 远程项目不出启动器段

SSH 项目的 PTY 是 ssh 启动器,**启动初期可能停在口令或 host key 确认交互上,预写的 `{命令}\r` 会被当口令消费** —— 命令丢失之外登录本身还可能失败一次;存了密码的连接则与 PTY 的 autofill 状态机抢同一次输入。

这条守卫仓库已经立过:`hydrate_project` 的自动续接对远程项目跳过 resume 预写,注释写的就是同一个原因;移动端 `can_start_session` 也把远程项目挡在发起会话之外。本 PR 与两者口径对齐 —— 远程项目菜单里**只出 shell 段**,点开就是普通终端。

WSL 项目不挡:本地 PTY 直接起 `wsl.exe`,没有口令交互那一段;移动端连 WSL 根项目一起挡是对话镜像盲发的问题,与桌面端无关。

## 一处行为变化(有意为之)

`shells.len() <= 1` 那道「单 shell 不弹菜单」的闸改为连启动器一起算(`should_show_new_terminal_menu`)。

**影响面**:启动器的读口径(`AppStore::mobile_relay`)在配置整块缺失时回落 `Default`、含预置的 Claude / Codex 两条,`launcher_count` 因此恒 ≥ 2 —— 除非用户把启动器删光。所以这是**所有**单 shell 用户点「+」从此都会弹菜单,不只是自己精简过 shell 列表的那批。

这是有意为之:本次的目的就是把启动器入口曝光出来,多的那一次点击换来的是「一键开 AI 会话」。远程项目是例外 —— 启动器为空,单 shell + 远程仍是点一下直接开。

## 不在本次范围

用户自配的非内置 CLI(如 gemini)能一键起来,但仍是普通终端、**没有状态徽章**。

放开 `AI_COMMANDS` 识别名单会让「哪些 pane 能被移动端远程写入任意文本」由用户配置决定 —— `build_snapshot` 按 `ai-working`/`ai-idle` 裁可见性,而 `MobileCommand.text` 是任意文本直写 PTY。用户随手配一条 `npm run dev` 启动器就会击穿 ADR 0001/0002 的「裸 shell 不可见、不可驱动」。要做得把「本地感知」与「移动端可驱动」拆成两级判据,单独立项更稳妥。

## 验证

- `cargo test --workspace` 绿(含 `single_option_gate_counts_launchers_too`、`launcher_section_hidden_for_remote_projects_only`)
- CI 全绿:改动行 rustfmt / i18n 生成一致性 / `cargo check --workspace --all-targets` / 改动行 clippy / whitespace
- macOS arm64 dmg 构建通过
- 菜单交互为手动验证(仓库无桌面前端 UI 测试基建,沿用现状)